### PR TITLE
feat(v0.4): tools.listChanged capability + agent_ping tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-21
+
+### Added
+- **`agent_ping` tool** — returns `{"server", "version", "agent_id"}`. Useful
+  for detecting a stale stdio child after an `a2a-mcp-bridge` upgrade:
+  clients can call it at session start and compare the reported version
+  against the installed package to decide whether to prompt an operator
+  restart.
+- **`tools.listChanged` capability advertised** at handshake time via a
+  `FastMCP` subclass (`A2AMcp`) that injects
+  `NotificationOptions(tools_changed=True)`. The project still registers
+  tools statically, but the capability is declared so future plugin-style
+  dynamic tool additions become a drop-in change without client restart.
+- Startup log now includes the running bridge version
+  (`starting a2a-mcp-bridge ... version=0.4.0`).
+- 4 new tests (85 total).
+
+### Documentation
+- `server.py` carries an extended module comment explaining why
+  `list_changed` alone cannot solve the "client still talks to an old
+  stdio server after upgrade" problem, and how `agent_ping` complements it.
+
 ## [0.3.0] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dynamic tool additions become a drop-in change without client restart.
 - Startup log now includes the running bridge version
   (`starting a2a-mcp-bridge ... version=0.4.0`).
-- 4 new tests (85 total).
+- 5 new tests (86 total).
+
+### Changed
+- **Telegram wake-up message format** — now names the reply-to `agent_id`
+  explicitly and shows the literal `agent_send(target="...")` call signature.
+  The previous v0.3 text could be misread by an LLM agent that confused the
+  A2A sender with a Telegram surface identity (bot username / chat peer),
+  causing replies to be routed to the wrong target. Regression test added.
 
 ### Documentation
 - `server.py` carries an extended module comment explaining why

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -6,10 +6,14 @@ import logging
 import os
 import re
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.lowlevel import NotificationOptions
+from mcp.server.stdio import stdio_server
 
 from .signals import SignalDir
 from .store import Store
@@ -25,6 +29,14 @@ logger = logging.getLogger("a2a_mcp_bridge")
 AGENT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 DEFAULT_SIGNAL_DIR = "/tmp/a2a-signals"  # advisory notification files
 DEFAULT_WAKE_REGISTRY = "~/.a2a-wake-registry.json"
+
+
+def _bridge_version() -> str:
+    """Return the installed a2a-mcp-bridge version, or 'unknown' if undiscoverable."""
+    try:
+        return _pkg_version("a2a-mcp-bridge")
+    except PackageNotFoundError:  # pragma: no cover — only hit in editable dev without install
+        return "unknown"
 
 
 def _resolve_agent_id() -> str:
@@ -77,6 +89,45 @@ def _load_waker() -> TelegramWaker | None:
     return TelegramWaker(registry)
 
 
+class A2AMcp(FastMCP):
+    """FastMCP subclass that advertises ``tools.listChanged`` capability.
+
+    Why this matters (v0.4 — Option A, future-proof):
+    ---------------------------------------------------
+    The MCP spec defines ``notifications/tools/list_changed`` to let a server
+    tell clients "my tool set changed, please re-fetch ``tools/list``". In this
+    project the tool set is registered statically at import time, so we never
+    actually emit this notification today. However, declaring the capability
+    early has two benefits:
+
+    1. MCP clients that observe the capability will subscribe to the
+       notification stream, so future dynamic tool additions (e.g. plugins,
+       per-session tool gating) become a drop-in change — no client-side
+       restart required.
+    2. The spec encourages servers to declare every capability they *might*
+       use; this keeps our handshake honest.
+
+    Note (documented caveat for Vincent's setup):
+    This does **not** solve the "client keeps talking to an old stdio server
+    after a version upgrade" issue. An upgraded binary only runs after the
+    parent process (Hermes gateway) restarts its stdio child. Emitting
+    ``list_changed`` from a new process reaches no one on the old channel.
+    The proper mitigation for that scenario is the new ``agent_ping`` tool
+    below, which lets a client query the server's running version and warn
+    the operator about a stale child.
+    """
+
+    async def run_stdio_async(self) -> None:
+        async with stdio_server() as (read_stream, write_stream):
+            await self._mcp_server.run(
+                read_stream,
+                write_stream,
+                self._mcp_server.create_initialization_options(
+                    notification_options=NotificationOptions(tools_changed=True),
+                ),
+            )
+
+
 def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None) -> FastMCP:
     store = Store(db_path)
     store.init_schema()
@@ -85,7 +136,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     signal_dir = SignalDir(signal_dir_path or _resolve_signal_dir())
     waker = _load_waker()
 
-    mcp = FastMCP("a2a-mcp-bridge")
+    mcp = A2AMcp("a2a-mcp-bridge")
 
     @mcp.tool()
     def agent_send(
@@ -151,6 +202,28 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             limit=limit,
         )
 
+    @mcp.tool()
+    def agent_ping() -> dict[str, Any]:
+        """Return the bridge's running version and the caller's agent_id.
+
+        Use this to detect a stale stdio child after an a2a-mcp-bridge upgrade.
+        The MCP ``tools/list_changed`` notification cannot help in that case
+        because the new binary only runs once the parent (Hermes gateway)
+        restarts its child process — the client is still talking to the old
+        server. Call ``agent_ping`` at session start and compare the returned
+        ``version`` against the installed package version (or a known-good
+        minimum) to decide whether to prompt the operator for a gateway
+        restart.
+
+        Returns:
+            {"version", "agent_id", "server": "a2a-mcp-bridge"}
+        """
+        return {
+            "server": "a2a-mcp-bridge",
+            "version": _bridge_version(),
+            "agent_id": agent_id,
+        }
+
     return mcp
 
 
@@ -163,10 +236,11 @@ def main() -> None:
     db_path = _resolve_db_path()
     signal_dir_path = _resolve_signal_dir()
     logger.info(
-        "starting a2a-mcp-bridge agent_id=%s db=%s signals=%s",
+        "starting a2a-mcp-bridge agent_id=%s db=%s signals=%s version=%s",
         agent_id,
         db_path,
         signal_dir_path,
+        _bridge_version(),
     )
     server = build_server(agent_id, db_path, signal_dir_path)
     server.run()

--- a/src/a2a_mcp_bridge/wake.py
+++ b/src/a2a_mcp_bridge/wake.py
@@ -81,10 +81,17 @@ def load_registry(path: str) -> dict[str, WakeEntry]:
 
 
 def _format_message(sender_id: str) -> str:
-    """Short, direct Telegram wake-up message. Kept under 200 chars."""
+    """Explicit wake-up Telegram message for LLM agents.
+
+    The format names the reply-target explicitly so the receiving agent
+    (an LLM reading the Telegram text) cannot confuse the A2A ``sender_id``
+    with any surface-level Telegram identity (bot username, chat peer, etc.).
+    """
     return (
-        f"Message A2A de {sender_id} : consulte ton inbox avec agent_inbox "
-        f"et réponds via agent_send."
+        "Nouveau message A2A reçu.\n"
+        f"- sender (reply-to) : {sender_id}\n"
+        "- Pour lire          : agent_inbox()\n"
+        f'- Pour répondre      : agent_send(target="{sender_id}", message="...")'
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -66,3 +67,85 @@ def test_main_exits_without_agent_id(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(SystemExit) as exc:
         server_module.main()
     assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# v0.4 — tools.listChanged capability (Option A, future-proof) + agent_ping
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_version_returns_string() -> None:
+    """_bridge_version always returns a non-empty string (installed or 'unknown')."""
+    v = server_module._bridge_version()
+    assert isinstance(v, str)
+    assert v  # never empty
+
+
+def test_a2amcp_advertises_tools_changed_capability(tmp_path: Path) -> None:
+    """The server handshake must declare tools.listChanged=True.
+
+    Even though we don't dynamically add/remove tools today, declaring the
+    capability lets clients subscribe to future updates without restart.
+    """
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    # FastMCP's internal low-level server is at _mcp_server
+    init_opts = mcp._mcp_server.create_initialization_options(
+        notification_options=server_module.NotificationOptions(tools_changed=True),
+    )
+    caps = init_opts.capabilities
+    assert caps.tools is not None
+    assert caps.tools.listChanged is True
+
+
+def test_agent_ping_returns_version_and_agent_id(tmp_path: Path) -> None:
+    """The agent_ping tool must expose version + agent_id for staleness checks."""
+    import anyio
+
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+
+    # FastMCP exposes call_tool() to invoke registered tools by name
+    async def _invoke() -> Any:
+        return await mcp.call_tool("agent_ping", {})
+
+    result = anyio.run(_invoke)
+    # FastMCP.call_tool returns (content, structured) tuple in recent versions;
+    # fall back to a dict-like shape for older versions.
+    payload: dict[str, Any]
+    if isinstance(result, tuple):
+        # (content_list, structured_output) — we want structured_output
+        payload = result[1] if len(result) > 1 and isinstance(result[1], dict) else {}
+        if not payload and result[0]:
+            # Older shape: list[TextContent] with JSON body
+            import json
+
+            first = result[0][0]
+            text = getattr(first, "text", None)
+            if text:
+                payload = json.loads(text)
+    elif isinstance(result, dict):
+        payload = result
+    else:
+        payload = {}
+
+    assert payload.get("server") == "a2a-mcp-bridge"
+    assert payload.get("agent_id") == "alice"
+    assert isinstance(payload.get("version"), str) and payload["version"]
+
+
+def test_build_server_registers_agent_ping_tool(tmp_path: Path) -> None:
+    """agent_ping must be listed among the registered MCP tools."""
+    import anyio
+
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+
+    async def _list() -> Any:
+        return await mcp.list_tools()
+
+    tools = anyio.run(_list)
+    names = {t.name for t in tools}
+    assert "agent_ping" in names
+    # Sanity: the v0.1-v0.3 tools are still there
+    assert {"agent_send", "agent_inbox", "agent_list", "agent_subscribe"} <= names

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -143,3 +143,36 @@ class TestTelegramWakerWake:
         body = up.call_args.args[0].data.decode("utf-8")
         # The prompt should hint at agent_inbox so the recipient knows what to do
         assert "agent_inbox" in body
+
+    def test_message_names_reply_target_explicitly(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
+        """Regression guard (v0.4.1): the wake-up text must make the reply-to
+        agent_id unambiguous so an LLM reading it cannot confuse it with a
+        Telegram bot username or chat peer.
+        """
+        waker = TelegramWaker(waker_registry)
+        fake_response = MagicMock()
+        fake_response.__enter__.return_value = fake_response
+        fake_response.read.return_value = b"{}"
+        fake_response.status = 200
+
+        with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake_response) as up:
+            waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
+
+        # The HTTP POST body is urlencoded form data; decode it to recover the text
+        import urllib.parse as _up
+
+        encoded = up.call_args.args[0].data.decode("utf-8")
+        parsed = dict(_up.parse_qsl(encoded))
+        text = parsed["text"]
+
+        # Must name the sender as a copy-pasteable agent_id
+        assert "vlbeau-glm51" in text
+        # Must mention both tools the recipient will use
+        assert "agent_inbox" in text
+        assert "agent_send" in text
+        # Must show the exact reply-to call signature
+        assert 'target="vlbeau-glm51"' in text
+        # Must label the sender as the reply target so LLMs don't guess
+        assert "reply-to" in text.lower()


### PR DESCRIPTION
## What

Two small, complementary improvements targeting MCP client upgrade UX:

### 1. Declare `tools.listChanged` capability (future-proof)

A `FastMCP` subclass (`A2AMcp`) injects `NotificationOptions(tools_changed=True)` into the handshake so MCP clients subscribe to the `notifications/tools/list_changed` stream. The project still registers tools statically; this lands the plumbing so a later plugin-style feature becomes a drop-in change without client restart.

### 2. New `agent_ping` tool

Returns `{server, version, agent_id}`. A client can call it at session start and compare `version` against the installed package to detect a stale stdio child. This handles the concrete problem we hit: after upgrading the binary, a long-lived Hermes gateway still talks to the old process, invisible to `list_changed`.

## Why both

`list_changed` and `agent_ping` solve **different** issues:

| Scenario | Fix |
|---|---|
| New tool added at runtime (plugin, session gating) | `list_changed` notification |
| New tool added via upgraded binary + parent didn't restart child | `agent_ping` version check |

Only the second scenario matters in production today. The first is speculative but cheap to prepare for.

## Testing

- 4 new tests in `tests/test_server.py` (85 total)
- `ruff` + `mypy` clean
- Manual smoke test: `a2a-mcp-bridge serve` logs `version=0.4.0` at startup

## Compatibility

100% backwards-compatible. No env vars added, no behaviour changed for existing tools. Agents using v0.1–v0.3 clients see an extra tool they can ignore.

## Version

`0.3.0` → `0.4.0` (semver minor: additive feature)

---

Ready to merge if the idea flies. — Opus (vlbeau-main)
