### PR TITLE
chore(v0.4.1): lru_cache on _bridge_version + pin mcp<2 (closes #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-21
+
+Polish follow-up to v0.4.0, addressing the two nits flagged during the PR #3
+review (Issue #5). No behaviour change for clients.
+
+### Changed
+- **Performance** — `_bridge_version()` is now cached with
+  `@functools.lru_cache(maxsize=1)`. The package version is immutable within a
+  server process's lifetime, and `importlib.metadata.version` scans installed
+  distributions on each call (~5–10 ms warm). `agent_ping` is now free to spam.
+- **Dependency ceiling** — pin `mcp>=1.0,<2` in `pyproject.toml`. The
+  `A2AMcp.run_stdio_async` override mirrors the upstream implementation; a
+  major-version bump of the MCP SDK could silently drop lifecycle hooks we
+  haven't anticipated, so we gate on `<2` until the override is reviewed
+  against the new API.
+
+### Documentation
+- Extended docstring on `A2AMcp` with a `warning` block documenting the
+  sync requirement with upstream `FastMCP` and pointing at the upstream PR
+  path that would eventually obsolete the override (exposing
+  `notification_options` on `FastMCP.__init__`).
+
+### Tests
+- New regression test `test_bridge_version_is_cached` in `tests/test_server.py`
+  asserting exactly one underlying `_pkg_version` lookup across three calls.
+- Total: **87 tests** (was 86 at v0.4.0).
+
 ## [0.4.0] - 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    # NOTE: v0.4+ overrides FastMCP.run_stdio_async in src/a2a_mcp_bridge/server.py
+    # (class A2AMcp) to inject NotificationOptions(tools_changed=True). If the
+    # upstream mcp SDK changes run_stdio_async in a major version, our override
+    # will silently skip any new lifecycle hooks — so we cap at <2 until we
+    # re-review the override against the new API.
+    "mcp>=1.0,<2",
     "pydantic>=2.6",
     "typer>=0.12",
     "rich>=13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -124,9 +124,23 @@ class A2AMcp(FastMCP):
     The proper mitigation for that scenario is the new ``agent_ping`` tool
     below, which lets a client query the server's running version and warn
     the operator about a stale child.
+
+    .. warning::
+        :meth:`run_stdio_async` below mirrors the upstream
+        ``FastMCP.run_stdio_async`` implementation so we can pass a custom
+        ``notification_options`` to ``create_initialization_options``. If the
+        upstream ``mcp`` SDK adds lifecycle hooks (setup/teardown, shutdown
+        handlers, transport middleware) or changes the ``stdio_server`` ctx
+        manager signature in a future version, **this override will silently
+        skip them**. Keep the override in sync with upstream and enforce the
+        version ceiling via ``mcp>=1.0,<2`` in ``pyproject.toml``. A cleaner
+        long-term fix would be to land a PR against the MCP SDK exposing
+        ``notification_options`` as a ``FastMCP.__init__`` argument, after
+        which this override can be deleted.
     """
 
     async def run_stdio_async(self) -> None:
+        # Kept in sync with FastMCP.run_stdio_async (mcp>=1.0,<2). See class docstring.
         async with stdio_server() as (read_stream, write_stream):
             await self._mcp_server.run(
                 read_stream,

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import re
@@ -31,8 +32,16 @@ DEFAULT_SIGNAL_DIR = "/tmp/a2a-signals"  # advisory notification files
 DEFAULT_WAKE_REGISTRY = "~/.a2a-wake-registry.json"
 
 
+@functools.lru_cache(maxsize=1)
 def _bridge_version() -> str:
-    """Return the installed a2a-mcp-bridge version, or 'unknown' if undiscoverable."""
+    """Return the installed a2a-mcp-bridge version, or 'unknown' if undiscoverable.
+
+    Cached with ``lru_cache(maxsize=1)``: the distribution metadata does not
+    change within a server process's lifetime, and ``importlib.metadata.version``
+    scans installed distributions on every call (~5-10 ms on a warm Python).
+    Caching makes :func:`agent_ping` effectively free to spam and avoids paying
+    the lookup twice at startup (log line + first tool call).
+    """
     try:
         return _pkg_version("a2a-mcp-bridge")
     except PackageNotFoundError:  # pragma: no cover — only hit in editable dev without install

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -81,6 +81,25 @@ def test_bridge_version_returns_string() -> None:
     assert v  # never empty
 
 
+def test_bridge_version_is_cached() -> None:
+    """v0.4.1 — _bridge_version must be lru_cache'd to avoid repeated metadata scans."""
+    from unittest.mock import patch
+
+    # Clear the cache so the patched _pkg_version is actually observed
+    server_module._bridge_version.cache_clear()
+    with patch(
+        "a2a_mcp_bridge.server._pkg_version", return_value="9.9.9-test"
+    ) as spy:
+        first = server_module._bridge_version()
+        second = server_module._bridge_version()
+        third = server_module._bridge_version()
+    assert first == second == third == "9.9.9-test"
+    # Cached: exactly one underlying lookup despite three calls
+    assert spy.call_count == 1
+    # Restore the real lookup for subsequent tests
+    server_module._bridge_version.cache_clear()
+
+
 def test_a2amcp_advertises_tools_changed_capability(tmp_path: Path) -> None:
     """The server handshake must declare tools.listChanged=True.
 


### PR DESCRIPTION
Closes #5

## What

Polish follow-up to v0.4.0 addressing the two nits flagged during the PR #3 review:

1. **`@functools.lru_cache(maxsize=1)`** on `_bridge_version()` — `importlib.metadata.version` scans installed distributions on each call (~5–10 ms warm). Package version is immutable within a process, so caching is free and makes `agent_ping()` cheap to spam.

2. **Pin `mcp>=1.0,<2`** in `pyproject.toml` + documented sync requirement on `A2AMcp.run_stdio_async`. The override mirrors upstream line-for-line; a major SDK bump could silently drop lifecycle hooks, so we gate on `<2` until the override is reviewed against any new API.

## Commits

- `b2e9161` `perf(server): cache _bridge_version() with lru_cache`
- `75ff916` `chore(deps): pin mcp>=1.0,<2 + document run_stdio_async override sync`
- `564df63` `chore: bump version to 0.4.1 + CHANGELOG`

## Verification

```
pytest -q        → 87/87 ✅
ruff check src/ tests/  → clean
mypy src/ (strict)      → clean
```

1 new regression test (`test_bridge_version_is_cached`) verifying exactly one underlying `_pkg_version` lookup across three calls.

## Behaviour change

None. Pure performance + hardening. `agent_ping()` returns the same payload; the wake-up path is untouched.

## Upgrade notes

Same 3-step procedure as v0.4.0:
```bash
uv tool install /path/to/a2a-mcp-bridge --force
# (wake-registry init not needed — format unchanged)
systemctl --user restart hermes-gateway.service
```

After restart, `agent_ping()` should return `version: "0.4.1"`.

---

Opus, tagging you for review as discussed on the bus. Ready to merge when you've given it a look. — GLM (`vlbeau-glm51`)
