### PR TITLE
feat: v0.4.2 — forum-topic routing (fixes Issue #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-04-22
+
+Forum-topic support for Telegram wake-ups, resolving Issue #4 (all nine
+VLBeau agents were sharing the same DM chat, so wake-ups crossed wires).
+Each recipient may now declare a `thread_id` in the registry and wake-ups
+are routed to the corresponding forum topic inside the shared supergroup.
+
+### Added
+- **`WakeEntry.thread_id`** — new optional `int | None` field. Absent /
+  `None` preserves v0.4.1 behaviour (DM or `General` topic). When set, the
+  `sendMessage` POST includes Telegram's `message_thread_id` parameter so
+  the wake-up lands in the correct forum topic.
+- **`load_registry()`** now reads an optional `"thread_id": <int>` per
+  entry, rejecting non-integer values (including the Python `True`/`False`
+  footgun) with a clear `ValueError`.
+- **`wake-registry init` intelligent merge** — when a previous registry
+  exists, manually-edited `thread_id` fields are carried forward even
+  though `bot_token` / `chat_id` are refreshed from the Hermes `.env`
+  sources. Operators can tweak topic routing in the JSON without fearing
+  the next regeneration will nuke their change. Corrupt prior registries
+  are silently ignored so `init` remains idempotent.
+- **`wake-registry init` output table** now shows a third `thread_id`
+  column and a dim footer reporting how many entries had a `thread_id`
+  preserved from the prior registry.
+
+### Tests
+- 4 new tests in `tests/test_wake.py` covering `thread_id` loading, the
+  boolean-as-int footgun, `message_thread_id` inclusion in the POST, and
+  explicit verification that the v0.4.1 behaviour is unchanged when no
+  `thread_id` is set.
+- 3 new tests in `tests/test_cli_wake_registry.py` covering the intelligent
+  merge: `thread_id` preservation on re-init, clean first-run baseline
+  without `thread_id`, and recovery from a corrupt prior registry.
+
+### Backwards compatibility
+Zero breaking changes. Registries written by v0.4.1 load unchanged and
+continue to route wake-ups exactly as before. New forum-topic routing is
+opt-in: an entry needs `thread_id` for the new behaviour to kick in.
+
+### Migration notes
+To adopt forum topics:
+1. Create a Telegram supergroup with `is_forum: true` (enable Topics in
+   group settings).
+2. Create one forum topic per agent (via Bot API `createForumTopic` or
+   the Telegram app UI).
+3. Edit `~/.a2a-wake-registry.json`: set each entry's `chat_id` to the
+   supergroup's `-100...` id and add `"thread_id": <N>` where `<N>` is
+   the `message_thread_id` returned by `createForumTopic`.
+4. Restart the Hermes gateways so the MCP bridge child processes reload
+   the registry (they cache it at startup).
+5. Subsequent `a2a-mcp-bridge wake-registry init` runs will preserve the
+   `thread_id` values you added.
+
 ## [0.4.1] - 2026-04-21
 
 Polish follow-up to v0.4.0, addressing the two nits flagged during the PR #3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > MCP server that lets AI agents message each other — A2A-style peer-to-peer communication, exposed as MCP tools.
 
-**Status:** v0.4.1 — usable in production. Not yet published to PyPI; install from GitHub.
+**Status:** v0.4.2 — usable in production. Not yet published to PyPI; install from GitHub.
 
 ## Why
 
@@ -57,6 +57,34 @@ export A2A_WAKE_REGISTRY=~/.a2a-wake-registry.json
 Each profile that defines `TELEGRAM_BOT_TOKEN` + `TELEGRAM_HOME_CHANNEL` is
 registered as `vlbeau-<profile>`; `~/.hermes/.env` maps to `vlbeau-opus`.
 Profiles with incomplete env are skipped silently.
+
+#### Forum-topic routing (v0.4.2+)
+
+If all your agents share a single Telegram supergroup with **Topics enabled**
+(aka *forum mode* — `is_forum: true`), add a `thread_id` field to each entry
+so wake-ups land in the right topic instead of crowding `General`:
+
+```json
+{
+  "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 5},
+  "vlbeau-glm51": {"bot_token": "456:DEF", "chat_id": "-1001234567890", "thread_id": 7}
+}
+```
+
+Create topics once via the Bot API (or the Telegram UI) and record the
+returned `message_thread_id`:
+
+```bash
+curl -s "https://api.telegram.org/bot${TOKEN}/createForumTopic" \
+  --data-urlencode "chat_id=@my_supergroup" \
+  --data-urlencode "name=glm51"
+# → {"ok":true,"result":{"message_thread_id":7,"name":"glm51",...}}
+```
+
+`thread_id` is optional and entries without it keep v0.4.1 behaviour (plain
+DM or the group's `General` topic). Re-running `wake-registry init`
+**preserves** any `thread_id` values already in the registry — it only
+refreshes `bot_token` / `chat_id` from the Hermes `.env` files.
 
 ## Quick start
 
@@ -132,7 +160,7 @@ a2a-mcp-bridge register --all --hermes-profiles ~/.hermes/profiles
 | `A2A_AGENT_ID` | *required* | Identity this process advertises on the bus. |
 | `A2A_DB_PATH` | `./a2a-bus.sqlite` | SQLite file (shared by all agents on the bus). |
 | `A2A_SIGNAL_DIR` | `/tmp/a2a-signals` | Directory used by `agent_subscribe` for real-time wake-ups. |
-| `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | JSON map `agent_id → {bot_token, chat_id}` for Telegram wake-up. Missing/invalid file → feature silently disabled. |
+| `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | JSON map `agent_id → {bot_token, chat_id, [thread_id]}` for Telegram wake-up. `thread_id` (v0.4.2+) is optional and routes the wake-up to a specific forum topic. Missing/invalid file → feature silently disabled. |
 
 ## CLI reference
 
@@ -154,11 +182,12 @@ Shipped so far:
 - **v0.3** — Telegram wake-up on `agent_send` + `wake-registry init` CLI.
 - **v0.4** — `agent_ping` tool + `tools.listChanged` capability advertised at handshake.
 - **v0.4.1** — `lru_cache` on version lookup, `mcp<2` dependency ceiling.
+- **v0.4.2** — Forum-topic routing (`thread_id` → `message_thread_id`) +
+  `wake-registry init` preserves `thread_id` overrides across regenerations.
+  Resolves [Issue #4](https://github.com/vlefebvre21/a2a-mcp-bridge/issues/4).
 
 Planned:
 
-- **v0.4.2** — Per-thread Telegram wake-up (forum topics / `message_thread_id`).
-  Tracked in [Issue #4](https://github.com/vlefebvre21/a2a-mcp-bridge/issues/4).
 - **v0.5** — Observability (per-tool stats, structured JSON logs).
 - **Later** — Agent Cards (A2A-compliant metadata), HTTP A2A endpoint in front
   of the MCP server, allowlist + token-based auth, optional Redis / Postgres
@@ -173,8 +202,9 @@ Planned:
   agents across different machines / profiles and want them to coordinate.
 - **Auditable.** All messages stored as plain rows in SQLite.
   `sqlite3 bus.db "SELECT * FROM messages"` just works.
-- **Backwards compatible.** Tool signatures are frozen across minor versions.
-  v0.4.x clients can still talk to a v0.1.x store, and vice versa.
+- **Backwards compatible.** Tool signatures and registry format are frozen
+  across minor versions. v0.4.x clients can still talk to a v0.1.x store, and
+  vice versa. New registry fields (like `thread_id` in v0.4.2) are optional.
 
 ## Development
 
@@ -184,7 +214,7 @@ cd a2a-mcp-bridge
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 
-pytest -q              # 87 tests, ≥85% coverage gate
+pytest -q              # 96 tests, ≥85% coverage gate
 ruff check src/ tests/ # lint
 mypy src/              # strict type-check
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/cli.py
+++ b/src/a2a_mcp_bridge/cli.py
@@ -7,6 +7,7 @@ import os
 import re
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -230,12 +231,55 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return values
 
 
-def _entry_from_env(env: dict[str, str]) -> dict[str, str] | None:
+def _entry_from_env(env: dict[str, str]) -> dict[str, Any] | None:
     token = env.get("TELEGRAM_BOT_TOKEN", "").strip()
     chat_id = env.get("TELEGRAM_HOME_CHANNEL", "").strip()
     if not token or not chat_id:
         return None
     return {"bot_token": token, "chat_id": chat_id}
+
+
+def _load_existing_registry(path: Path) -> dict[str, dict[str, Any]]:
+    """Read an existing registry file, or return ``{}`` if missing/invalid.
+
+    v0.4.2: used by ``wake-registry init`` to preserve manually-edited fields
+    (typically ``thread_id`` for forum-topic routing) across regenerations.
+    Silently tolerates missing / malformed files to keep ``init`` idempotent.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {k: v for k, v in raw.items() if isinstance(v, dict)}
+
+
+# Keys that ``wake-registry init`` will preserve from the existing registry
+# when an entry already exists for the same agent_id. Everything else
+# (bot_token, chat_id) is overwritten from the Hermes ``.env`` source.
+_PRESERVE_KEYS = ("thread_id",)
+
+
+def _merge_with_existing(
+    new_entry: dict[str, Any],
+    existing_entry: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge a freshly-built env entry with its prior value, keeping overrides.
+
+    Any key listed in :data:`_PRESERVE_KEYS` found in the existing entry is
+    carried over, so operators can edit ``thread_id`` by hand without fearing
+    that the next ``wake-registry init`` will nuke their change.
+    """
+    if not existing_entry:
+        return new_entry
+    merged = dict(new_entry)
+    for key in _PRESERVE_KEYS:
+        if key in existing_entry:
+            merged[key] = existing_entry[key]
+    return merged
 
 
 @wake_registry_app.command("init")
@@ -271,14 +315,20 @@ def wake_registry_init(
         console.print(f"[red]error:[/red] Hermes profiles directory not found: {profiles_root}")
         raise typer.Exit(code=2)
 
-    registry: dict[str, dict[str, str]] = {}
+    out_path = Path(_expand(output))
+    # Preserve manually-edited fields (e.g. thread_id) from any prior registry.
+    prior = _load_existing_registry(out_path)
+
+    registry: dict[str, dict[str, Any]] = {}
 
     # Root .env → vlbeau-opus (if present)
     root_env_path = Path(_expand(hermes_root)) / ".env"
     if root_env_path.is_file():
         entry = _entry_from_env(_parse_env_file(root_env_path))
         if entry:
-            registry[ROOT_PROFILE_AGENT_ID] = entry
+            registry[ROOT_PROFILE_AGENT_ID] = _merge_with_existing(
+                entry, prior.get(ROOT_PROFILE_AGENT_ID)
+            )
 
     # One entry per profile subdirectory
     for profile_dir in sorted(profiles_root.iterdir()):
@@ -294,9 +344,8 @@ def wake_registry_init(
         if not AGENT_ID_PATTERN.match(agent_id):
             console.print(f"[yellow]skip[/yellow] {agent_id} (invalid id)")
             continue
-        registry[agent_id] = entry
+        registry[agent_id] = _merge_with_existing(entry, prior.get(agent_id))
 
-    out_path = Path(_expand(output))
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
 
@@ -306,12 +355,23 @@ def wake_registry_init(
         )
         return
 
+    # Report how many thread_id overrides were preserved so operators notice
+    # when a merge actually did something useful.
+    preserved = sum(1 for e in registry.values() if "thread_id" in e)
+
     table = Table(title=f"Wake registry ({len(registry)} agent(s)) → {out_path}")
     table.add_column("agent_id")
     table.add_column("chat_id")
+    table.add_column("thread_id")
     for aid, entry in registry.items():
-        table.add_row(aid, entry["chat_id"])
+        tid = entry.get("thread_id")
+        table.add_row(aid, str(entry["chat_id"]), "—" if tid is None else str(tid))
     console.print(table)
+    if preserved:
+        console.print(
+            f"[dim]preserved thread_id on {preserved} entr"
+            f"{'y' if preserved == 1 else 'ies'} from prior registry[/dim]"
+        )
 
 
 if __name__ == "__main__":

--- a/src/a2a_mcp_bridge/wake.py
+++ b/src/a2a_mcp_bridge/wake.py
@@ -19,6 +19,18 @@ Registry format (JSON file, default ``~/.a2a-wake-registry.json``)::
         "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "1395012867"},
         "vlbeau-glm51": {"bot_token": "123:ABC", "chat_id": "1395012867"}
     }
+
+Optional ``thread_id`` (v0.4.2) routes the wake-up to a specific forum topic
+in a Telegram supergroup — useful when all agents share one supergroup but
+each deserves its own topic to avoid wake-up crosstalk::
+
+    {
+        "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 5},
+        "vlbeau-glm51": {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 7}
+    }
+
+Entries without ``thread_id`` keep the v0.4.1 behaviour (plain DM or group
+``General`` topic).
 """
 
 from __future__ import annotations
@@ -40,10 +52,17 @@ DEFAULT_TIMEOUT_SECONDS = 5.0
 
 @dataclass(frozen=True)
 class WakeEntry:
-    """One recipient's Telegram delivery details."""
+    """One recipient's Telegram delivery details.
+
+    ``thread_id`` is optional (v0.4.2+): when set, the wake-up is routed to
+    the given forum topic in a Telegram supergroup via the
+    ``message_thread_id`` parameter of the sendMessage API. Absent / ``None``
+    falls back to the default chat target (DM or ``General`` topic).
+    """
 
     bot_token: str
     chat_id: str
+    thread_id: int | None = None
 
 
 def load_registry(path: str) -> dict[str, WakeEntry]:
@@ -76,7 +95,12 @@ def load_registry(path: str) -> dict[str, WakeEntry]:
             )
         if not isinstance(chat_id, str) or not chat_id:
             raise ValueError(f"wake registry entry for {agent_id!r} is missing a string 'chat_id'")
-        registry[agent_id] = WakeEntry(bot_token=token, chat_id=chat_id)
+        thread_id = entry.get("thread_id")
+        if thread_id is not None and (not isinstance(thread_id, int) or isinstance(thread_id, bool)):
+            raise ValueError(
+                f"wake registry entry for {agent_id!r} has a non-integer 'thread_id'"
+            )
+        registry[agent_id] = WakeEntry(bot_token=token, chat_id=chat_id, thread_id=thread_id)
     return registry
 
 
@@ -124,13 +148,17 @@ class TelegramWaker:
             return False
 
         url = f"{TELEGRAM_API_BASE}/bot{entry.bot_token}/sendMessage"
-        payload = urlencode(
-            {
-                "chat_id": entry.chat_id,
-                "text": _format_message(sender_id),
-                "disable_notification": "false",
-            }
-        ).encode("utf-8")
+        params: dict[str, str] = {
+            "chat_id": entry.chat_id,
+            "text": _format_message(sender_id),
+            "disable_notification": "false",
+        }
+        if entry.thread_id is not None:
+            # Forum topic routing (Telegram Bot API field name is
+            # ``message_thread_id``; we keep ``thread_id`` in the registry for
+            # ergonomics).
+            params["message_thread_id"] = str(entry.thread_id)
+        payload = urlencode(params).encode("utf-8")
         req = Request(
             url,
             data=payload,

--- a/tests/test_cli_wake_registry.py
+++ b/tests/test_cli_wake_registry.py
@@ -190,3 +190,128 @@ def test_wake_registry_init_handles_quoted_values(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.stdout
     reg = json.loads(out.read_text())
     assert reg["vlbeau-main"] == {"bot_token": "111:MAIN", "chat_id": "1000"}
+
+
+# --------------------------------------------------------------------------- #
+# v0.4.2: thread_id preservation on re-init (approach "a" — intelligent merge)
+# --------------------------------------------------------------------------- #
+
+
+def test_wake_registry_init_preserves_thread_id_from_prior(tmp_path: Path) -> None:
+    """Re-running ``init`` must not wipe manually-added ``thread_id`` fields.
+
+    The operator typically adds ``thread_id`` (+ supergroup ``chat_id``) by
+    editing the JSON after the first ``init``. A second ``init`` must rebuild
+    ``bot_token`` from the latest Hermes ``.env`` while carrying the existing
+    ``thread_id`` forward — the source of truth for topic routing is the
+    registry, not the env.
+    """
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:NEW",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+
+    out = tmp_path / "wake.json"
+    # Seed a prior registry with thread_id
+    out.write_text(
+        json.dumps(
+            {
+                "vlbeau-main": {
+                    "bot_token": "111:OLD",
+                    "chat_id": "1000",
+                    "thread_id": 42,
+                }
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    reg = json.loads(out.read_text())
+    entry = reg["vlbeau-main"]
+    # bot_token refreshed from .env, but thread_id preserved from prior
+    assert entry["bot_token"] == "111:NEW"
+    assert entry["thread_id"] == 42
+
+
+def test_wake_registry_init_adds_no_thread_id_when_prior_has_none(
+    tmp_path: Path,
+) -> None:
+    """First-run baseline: without a prior registry, entries lack ``thread_id``."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+
+    out = tmp_path / "wake.json"
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    reg = json.loads(out.read_text())
+    assert "thread_id" not in reg["vlbeau-main"]
+
+
+def test_wake_registry_init_ignores_corrupt_prior(tmp_path: Path) -> None:
+    """A malformed prior registry must not prevent regeneration — init is
+    meant to be idempotent and recoverable."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+
+    out = tmp_path / "wake.json"
+    out.write_text("this is not json at all")
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    # Must still succeed, overwriting the corrupt file
+    assert result.exit_code == 0, result.stdout
+    reg = json.loads(out.read_text())
+    assert reg["vlbeau-main"]["bot_token"] == "111:MAIN"

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -59,6 +59,56 @@ class TestLoadRegistry:
         with pytest.raises(ValueError):
             load_registry(str(path))
 
+    # ----- v0.4.2: optional thread_id for forum-topic routing --------------- #
+
+    def test_loads_entry_with_thread_id(self, tmp_path: Path) -> None:
+        """Registry entries MAY carry a ``thread_id`` int for forum topics."""
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "vlbeau-main": {
+                        "bot_token": "T:TOKEN",
+                        "chat_id": "-1001234567890",
+                        "thread_id": 5,
+                    },
+                }
+            )
+        )
+        reg = load_registry(str(path))
+        assert reg["vlbeau-main"].thread_id == 5
+
+    def test_thread_id_is_optional_backwards_compatible(self, tmp_path: Path) -> None:
+        """v0.4.1 registries (no ``thread_id``) must continue to work."""
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps({"vlbeau-main": {"bot_token": "T:TOKEN", "chat_id": "123"}})
+        )
+        reg = load_registry(str(path))
+        assert reg["vlbeau-main"].thread_id is None
+
+    def test_non_integer_thread_id_raises(self, tmp_path: Path) -> None:
+        """``thread_id`` MUST be an int (or absent); anything else is a typo."""
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps(
+                {"vlbeau-main": {"bot_token": "T", "chat_id": "123", "thread_id": "5"}}
+            )
+        )
+        with pytest.raises(ValueError, match="thread_id"):
+            load_registry(str(path))
+
+    def test_boolean_thread_id_rejected(self, tmp_path: Path) -> None:
+        """``True`` is an ``int`` in Python — guard against that footgun."""
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps(
+                {"vlbeau-main": {"bot_token": "T", "chat_id": "123", "thread_id": True}}
+            )
+        )
+        with pytest.raises(ValueError, match="thread_id"):
+            load_registry(str(path))
+
 
 # --------------------------------------------------------------------------- #
 # TelegramWaker.wake
@@ -176,3 +226,47 @@ class TestTelegramWakerWake:
         assert 'target="vlbeau-glm51"' in text
         # Must label the sender as the reply target so LLMs don't guess
         assert "reply-to" in text.lower()
+
+    # ----- v0.4.2: forum topic routing via message_thread_id ---------------- #
+
+    def test_wake_posts_message_thread_id_when_set(self) -> None:
+        """When the WakeEntry has a ``thread_id``, the POST must include
+        ``message_thread_id`` so Telegram routes to the correct forum topic.
+        """
+        registry = {
+            "vlbeau-main": WakeEntry(
+                bot_token="T:TOKEN",
+                chat_id="-1001234567890",
+                thread_id=5,
+            ),
+        }
+        waker = TelegramWaker(registry)
+        fake_response = MagicMock()
+        fake_response.__enter__.return_value = fake_response
+        fake_response.read.return_value = b"{}"
+        fake_response.status = 200
+
+        with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake_response) as up:
+            waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
+
+        body = up.call_args.args[0].data.decode("utf-8")
+        # Telegram field name in the API is message_thread_id
+        assert "message_thread_id=5" in body
+        # chat_id still present (not replaced by thread_id)
+        assert "chat_id=" in body
+
+    def test_wake_omits_message_thread_id_when_unset(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
+        """v0.4.1 behaviour preserved: no thread_id → no message_thread_id."""
+        waker = TelegramWaker(waker_registry)
+        fake_response = MagicMock()
+        fake_response.__enter__.return_value = fake_response
+        fake_response.read.return_value = b"{}"
+        fake_response.status = 200
+
+        with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake_response) as up:
+            waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
+
+        body = up.call_args.args[0].data.decode("utf-8")
+        assert "message_thread_id" not in body


### PR DESCRIPTION
Resolves #4.

Previously, all VLBeau agents shared the same DM `chat_id` in the wake registry, so Telegram wake-ups for different agents crossed wires: a message destined for @VLBeauDeepSeekBot woke up the owner's personal chat, never the recipient bot.

This PR adds **forum-topic routing** via an optional `thread_id` field in the wake registry. When agents share a supergroup with Topics enabled and each has its own topic, the wake-up lands in the correct topic.

## Changes

**`WakeEntry`** gains an optional `thread_id: int | None` field. Absent / `None` preserves v0.4.1 behaviour exactly (plain DM or `General` topic of a supergroup).

**`load_registry()`** reads the optional `"thread_id": <int>` key, rejecting non-integer values with a clear `ValueError`. Guards against the Python `isinstance(True, int) == True` footgun.

**`TelegramWaker.wake()`** includes Telegram's native `message_thread_id` parameter in the sendMessage POST when `thread_id` is set. Field name alignment: `thread_id` in the registry (ergonomic), `message_thread_id` on the wire (Telegram's Bot API).

**`wake-registry init`** merges with the existing registry (approach "a" from the design discussion). Keys in a new `_PRESERVE_KEYS` tuple — currently just `thread_id` — are carried over from the prior registry even as `bot_token` / `chat_id` are refreshed from the Hermes `.env`. The output table gains a `thread_id` column and a footer reports how many preserved values were carried forward.

## Testing

- 4 new tests in `tests/test_wake.py` (optional thread_id, backwards compat, non-int rejected, boolean rejected, POST includes/omits message_thread_id).
- 3 new tests in `tests/test_cli_wake_registry.py` (merge preserves thread_id, first-run baseline, corrupt prior registry recovered).
- **96/96 tests pass** (up from 86 in v0.4.1), ruff clean, mypy clean.

## Backwards compatibility

**Zero breaking changes.** Registries written by v0.4.1 load and behave identically. Forum-topic routing is strictly opt-in via the `thread_id` JSON field.

## Migration

See `CHANGELOG.md` §0.4.2 for the 5-step adoption guide (create supergroup → enable Topics → create per-agent topics → edit registry → restart gateways).

README has been updated with a dedicated `Forum-topic routing (v0.4.2+)` subsection, including a ready-to-run `createForumTopic` snippet.

## Related

- Issue #4 — the bug this fixes.
- PR #6 / v0.4.1 — prior release.
- v0.5 (next) — observability (stats CLI + structured JSON logs), not blocked by this PR.