### PR TITLE
feat: v0.4.3 — shared-wake-bot format (fixes self-wake dead-end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,108 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-04-22
+
+Shared-wake-bot format. Resolves the self-wake dead-end introduced by
+v0.4.2's forum-topic routing: in a Telegram supergroup, a bot never
+receives messages it posted itself, so routing the wake-up through the
+recipient's own token made the wake-up land in the topic but never
+trigger the recipient's gateway. v0.4.3 posts every wake-up through a
+single shared bot (typically `vlbeau-main`'s `@VLBeauBot`) so each
+recipient sees an actual incoming update from a different sender.
+
+### Added
+- **Registry format v2** — top-level `wake_bot_token` + `agents` object::
+
+    ```json
+    {
+      "wake_bot_token": "123:ABC",
+      "agents": {
+        "vlbeau-main":  {"chat_id": "-1001234567890", "thread_id": 5},
+        "vlbeau-glm51": {"chat_id": "-1001234567890", "thread_id": 7}
+      }
+    }
+    ```
+
+  The single `wake_bot_token` is used to POST every wake-up. Each entry
+  carries only `chat_id` (+ optional `thread_id`) — per-agent
+  `bot_token` is no longer needed or stored.
+
+- **Self-wake guard** — `TelegramWaker.wake()` silently returns `False`
+  when `agent_id == sender_id`, preventing wake-loops on the same
+  gateway if a buggy caller ever sends a message to itself.
+
+- **`uses_shared_token` property** on `TelegramWaker` for introspection
+  and future observability work.
+
+- **`message_thread_id` alias** — the registry accepts both `thread_id`
+  (preferred, shorter) and `message_thread_id` (Telegram-native) on
+  each entry. Operators typing the Bot API name by reflex no longer get
+  a silent drop.
+
+- **CLI `--wake-bot-profile <name>`** — selects the Hermes profile whose
+  `TELEGRAM_BOT_TOKEN` becomes the shared wake bot (default: `main`).
+
+- **CLI `--legacy-format`** — emits the v0.3 - v0.4.2 JSON shape for
+  operators who explicitly want per-agent DM wake-up (no supergroup).
+
+### Changed
+- **`load_registry()`** now returns a `(shared_token, entries)` tuple
+  instead of just `entries`. Callers inside the bridge are updated
+  (`server._load_waker`). External callers must unpack the tuple.
+
+- **`wake-registry init`** output now includes the format mode in its
+  title (`"shared-bot (main)"` vs `"legacy per-agent"`) so operators
+  can tell at a glance which shape they just wrote.
+
+- **`wake-registry init` errors loudly** when the new format is
+  requested but no wake-bot token can be resolved (profile missing
+  `TELEGRAM_BOT_TOKEN` and no prior registry to reuse from). Previously
+  this would have silently produced an unusable registry.
+
+### Deprecated
+- **Legacy per-agent `bot_token` format** (v0.3 - v0.4.2). Still accepted
+  by `load_registry()` — existing registries keep working — but
+  `load_registry()` now logs a migration warning the first time it
+  parses one. Run `a2a-mcp-bridge wake-registry init` to upgrade.
+
+### Tests
+- Test count: 111 (up from 96 in v0.4.2), ruff clean, mypy clean.
+- New in `tests/test_wake.py`:
+  - Full `TestLoadRegistrySharedBot` class (6 tests: happy path, empty
+    token rejected, agents must be dict, chat_id required,
+    `message_thread_id` alias accepted, no legacy warning).
+  - `TestTelegramWakerSharedBot` (4 tests: shared token wins over entry
+    token, thread_id routing, `uses_shared_token` flag, orphan entry
+    with no token returns False).
+  - `TestSelfWakeGuard` (2 tests: legacy + shared mode, both skip and
+    make no HTTP call).
+  - `test_legacy_format_warns_about_migration` — regression guard that
+    the deprecation warning is actually emitted.
+- New in `tests/test_cli_wake_registry.py`:
+  - `test_wake_registry_init_defaults_to_shared_bot_format`
+  - `test_wake_registry_init_uses_custom_wake_bot_profile`
+  - `test_wake_registry_init_errors_when_wake_bot_token_missing`
+  - `test_wake_registry_init_reuses_prior_wake_bot_token`
+  - `test_wake_registry_init_preserves_thread_id_across_regenerations`
+  - `test_wake_registry_init_migrates_legacy_prior_registry`
+  - `test_legacy_format_emits_old_shape`
+
+### Migration
+Existing v0.4.2 registries continue to work without change. To adopt
+the shared-wake-bot format (recommended for all supergroup setups):
+
+1. Verify `~/.hermes/profiles/main/.env` has a valid
+   `TELEGRAM_BOT_TOKEN` — that token becomes the shared wake bot.
+2. Run `a2a-mcp-bridge wake-registry init` — the command detects any
+   prior `thread_id` overrides and carries them forward into the new
+   format.
+3. Restart the Hermes gateways so MCP bridge child processes reload
+   the registry.
+
+Operators who prefer per-agent DM wake-ups (no supergroup) should run
+`a2a-mcp-bridge wake-registry init --legacy-format` instead.
+
 ## [0.4.2] - 2026-04-22
 
 Forum-topic support for Telegram wake-ups, resolving Issue #4 (all nine

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > MCP server that lets AI agents message each other — A2A-style peer-to-peer communication, exposed as MCP tools.
 
-**Status:** v0.4.2 — usable in production. Not yet published to PyPI; install from GitHub.
+**Status:** v0.4.3 — usable in production. Not yet published to PyPI; install from GitHub.
 
 ## Why
 
@@ -58,16 +58,27 @@ Each profile that defines `TELEGRAM_BOT_TOKEN` + `TELEGRAM_HOME_CHANNEL` is
 registered as `vlbeau-<profile>`; `~/.hermes/.env` maps to `vlbeau-opus`.
 Profiles with incomplete env are skipped silently.
 
-#### Forum-topic routing (v0.4.2+)
+#### Forum-topic routing (v0.4.2+) with a shared wake bot (v0.4.3+)
 
-If all your agents share a single Telegram supergroup with **Topics enabled**
-(aka *forum mode* — `is_forum: true`), add a `thread_id` field to each entry
-so wake-ups land in the right topic instead of crowding `General`:
+If all your agents share a single Telegram supergroup with **Topics
+enabled** (aka *forum mode* — `is_forum: true`), wake-ups must be
+posted through a **single shared bot** rather than each recipient's
+own bot. Why: Telegram does not deliver a bot its own messages, so a
+bot can't wake itself up. Using a neutral sender (typically
+`vlbeau-main`'s `@VLBeauBot`) makes each wake-up land in the target's
+topic *as an update from another user*, which actually triggers the
+recipient's gateway.
+
+The v0.4.3+ registry format:
 
 ```json
 {
-  "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 5},
-  "vlbeau-glm51": {"bot_token": "456:DEF", "chat_id": "-1001234567890", "thread_id": 7}
+  "wake_bot_token": "123:ABC_WAKE_BOT",
+  "agents": {
+    "vlbeau-main":  {"chat_id": "-1001234567890", "thread_id": 5},
+    "vlbeau-glm51": {"chat_id": "-1001234567890", "thread_id": 7},
+    "vlbeau-opus":  {"chat_id": "-1001234567890", "thread_id": 6}
+  }
 }
 ```
 
@@ -81,10 +92,25 @@ curl -s "https://api.telegram.org/bot${TOKEN}/createForumTopic" \
 # → {"ok":true,"result":{"message_thread_id":7,"name":"glm51",...}}
 ```
 
-`thread_id` is optional and entries without it keep v0.4.1 behaviour (plain
-DM or the group's `General` topic). Re-running `wake-registry init`
-**preserves** any `thread_id` values already in the registry — it only
-refreshes `bot_token` / `chat_id` from the Hermes `.env` files.
+`thread_id` is optional and entries without it keep v0.4.1 behaviour
+(plain DM or the group's `General` topic). Re-running
+`wake-registry init` **preserves** any `thread_id` values already in
+the registry — it only refreshes `chat_id` and the top-level
+`wake_bot_token` from the Hermes `.env` files.
+
+#### Legacy per-agent DM wake-up (v0.3 - v0.4.2)
+
+If you don't have a supergroup and just want each agent to receive
+wake-ups in its own 1-on-1 DM chat, pass `--legacy-format` to
+`wake-registry init`:
+
+```bash
+a2a-mcp-bridge wake-registry init --legacy-format
+```
+
+This emits the older shape with a `bot_token` per entry. Accepted
+indefinitely but deprecated — `load_registry()` logs a migration hint
+when it sees this format.
 
 ## Quick start
 
@@ -160,7 +186,7 @@ a2a-mcp-bridge register --all --hermes-profiles ~/.hermes/profiles
 | `A2A_AGENT_ID` | *required* | Identity this process advertises on the bus. |
 | `A2A_DB_PATH` | `./a2a-bus.sqlite` | SQLite file (shared by all agents on the bus). |
 | `A2A_SIGNAL_DIR` | `/tmp/a2a-signals` | Directory used by `agent_subscribe` for real-time wake-ups. |
-| `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | JSON map `agent_id → {bot_token, chat_id, [thread_id]}` for Telegram wake-up. `thread_id` (v0.4.2+) is optional and routes the wake-up to a specific forum topic. Missing/invalid file → feature silently disabled. |
+| `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | JSON wake registry. v0.4.3+ shape: `{"wake_bot_token": "...", "agents": {<id>: {"chat_id": ..., "thread_id": ...}}}`. Legacy per-agent `{<id>: {"bot_token": ..., "chat_id": ...}}` still accepted (deprecated). Missing/invalid file → feature silently disabled. |
 
 ## CLI reference
 
@@ -185,6 +211,10 @@ Shipped so far:
 - **v0.4.2** — Forum-topic routing (`thread_id` → `message_thread_id`) +
   `wake-registry init` preserves `thread_id` overrides across regenerations.
   Resolves [Issue #4](https://github.com/vlefebvre21/a2a-mcp-bridge/issues/4).
+- **v0.4.3** — Shared-wake-bot format. A single `wake_bot_token` at the top
+  of the registry posts every wake-up, so forum-topic routing actually wakes
+  the recipient's gateway (a bot does not receive its own messages in a
+  supergroup). Self-wake guard added. Legacy per-agent format still accepted.
 
 Planned:
 
@@ -214,7 +244,7 @@ cd a2a-mcp-bridge
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 
-pytest -q              # 96 tests, ≥85% coverage gate
+pytest -q              # 111 tests, ≥85% coverage gate
 ruff check src/ tests/ # lint
 mypy src/              # strict type-check
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/cli.py
+++ b/src/a2a_mcp_bridge/cli.py
@@ -232,6 +232,27 @@ def _parse_env_file(path: Path) -> dict[str, str]:
 
 
 def _entry_from_env(env: dict[str, str]) -> dict[str, Any] | None:
+    """Build a wake registry entry shell from one profile's env.
+
+    Returns ``{"chat_id": ...}`` when at least a Telegram channel is known.
+    Returns ``None`` when the profile has no Telegram channel (can't wake).
+
+    ``bot_token`` from the env is intentionally *not* copied here: in the
+    v0.4.3+ shared-wake-bot format only the wake bot's token matters, and
+    legacy callers that still need per-agent tokens handle that elsewhere.
+    """
+    chat_id = env.get("TELEGRAM_HOME_CHANNEL", "").strip()
+    if not chat_id:
+        return None
+    return {"chat_id": chat_id}
+
+
+def _legacy_entry_from_env(env: dict[str, str]) -> dict[str, Any] | None:
+    """Legacy helper: includes per-agent ``bot_token`` in the entry.
+
+    Kept for operators who explicitly opt out of the shared-bot model via
+    ``--legacy-format``.
+    """
     token = env.get("TELEGRAM_BOT_TOKEN", "").strip()
     chat_id = env.get("TELEGRAM_HOME_CHANNEL", "").strip()
     if not token or not chat_id:
@@ -239,27 +260,39 @@ def _entry_from_env(env: dict[str, str]) -> dict[str, Any] | None:
     return {"bot_token": token, "chat_id": chat_id}
 
 
-def _load_existing_registry(path: Path) -> dict[str, dict[str, Any]]:
-    """Read an existing registry file, or return ``{}`` if missing/invalid.
+def _load_existing_registry(path: Path) -> tuple[str | None, dict[str, dict[str, Any]]]:
+    """Read an existing registry file, returning (prior_shared_token, prior_agents).
 
     v0.4.2: used by ``wake-registry init`` to preserve manually-edited fields
     (typically ``thread_id`` for forum-topic routing) across regenerations.
+    v0.4.3: also preserves the ``wake_bot_token`` if the prior registry used
+    the shared-bot format, so operators don't have to re-supply it.
     Silently tolerates missing / malformed files to keep ``init`` idempotent.
     """
     if not path.is_file():
-        return {}
+        return None, {}
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {}
+        return None, {}
     if not isinstance(raw, dict):
-        return {}
-    return {k: v for k, v in raw.items() if isinstance(v, dict)}
+        return None, {}
+
+    shared = raw.get("wake_bot_token")
+    if isinstance(shared, str) and shared:
+        agents = raw.get("agents")
+        if isinstance(agents, dict):
+            return shared, {k: v for k, v in agents.items() if isinstance(v, dict)}
+        return shared, {}
+
+    # Legacy format: each entry is a dict under the top-level keys.
+    return None, {k: v for k, v in raw.items() if isinstance(v, dict)}
 
 
 # Keys that ``wake-registry init`` will preserve from the existing registry
-# when an entry already exists for the same agent_id. Everything else
-# (bot_token, chat_id) is overwritten from the Hermes ``.env`` source.
+# when an entry already exists for the same agent_id. Chat_id and bot_token
+# are overwritten from the current Hermes .env source; everything else in
+# this tuple is carried forward so operators can edit freely.
 _PRESERVE_KEYS = ("thread_id",)
 
 
@@ -282,6 +315,11 @@ def _merge_with_existing(
     return merged
 
 
+# Name of the Hermes profile whose TELEGRAM_BOT_TOKEN is used as the shared
+# wake bot by default. Can be overridden via ``--wake-bot-profile``.
+DEFAULT_WAKE_BOT_PROFILE = "main"
+
+
 @wake_registry_app.command("init")
 def wake_registry_init(
     hermes_profiles: str = typer.Option(
@@ -300,6 +338,25 @@ def wake_registry_init(
         "-o",
         help="Where to write the generated wake-registry JSON file.",
     ),
+    wake_bot_profile: str = typer.Option(
+        DEFAULT_WAKE_BOT_PROFILE,
+        "--wake-bot-profile",
+        help=(
+            "Name of the Hermes profile whose TELEGRAM_BOT_TOKEN is used as "
+            "the shared wake bot. The shared bot posts every wake-up on "
+            "behalf of the sender so that Telegram supergroups with forum "
+            "topics work correctly. Ignored with --legacy-format."
+        ),
+    ),
+    legacy_format: bool = typer.Option(
+        False,
+        "--legacy-format",
+        help=(
+            "Emit the v0.3 - v0.4.2 registry format with one bot_token per "
+            "agent instead of the shared-wake-bot format. Only needed for "
+            "per-agent DM wake-up setups. Not recommended."
+        ),
+    ),
 ) -> None:
     """Build the Telegram wake-up registry from existing Hermes profiles.
 
@@ -307,8 +364,14 @@ def wake_registry_init(
     profile to agent_id ``vlbeau-<name>``. If ``<hermes-root>/.env`` exists, it
     is mapped to :data:`ROOT_PROFILE_AGENT_ID` (``vlbeau-opus``).
 
-    Profiles without both ``TELEGRAM_BOT_TOKEN`` and ``TELEGRAM_HOME_CHANNEL``
-    set are skipped silently — the command never fails on a partial environment.
+    Profiles without ``TELEGRAM_HOME_CHANNEL`` set are skipped silently —
+    the command never fails on a partial environment.
+
+    By default, emits the v0.4.3+ shared-wake-bot format: a single
+    ``wake_bot_token`` drawn from ``--wake-bot-profile`` (default ``main``)
+    is used for every wake-up, which is required for Telegram supergroups
+    with forum topics (a bot does not receive its own messages). Pass
+    ``--legacy-format`` to emit the old per-agent-token format instead.
     """
     profiles_root = Path(_expand(hermes_profiles))
     if not profiles_root.is_dir():
@@ -316,18 +379,19 @@ def wake_registry_init(
         raise typer.Exit(code=2)
 
     out_path = Path(_expand(output))
-    # Preserve manually-edited fields (e.g. thread_id) from any prior registry.
-    prior = _load_existing_registry(out_path)
+    prior_shared_token, prior_agents = _load_existing_registry(out_path)
 
-    registry: dict[str, dict[str, Any]] = {}
+    build_entry = _legacy_entry_from_env if legacy_format else _entry_from_env
+
+    registry_agents: dict[str, dict[str, Any]] = {}
 
     # Root .env → vlbeau-opus (if present)
     root_env_path = Path(_expand(hermes_root)) / ".env"
     if root_env_path.is_file():
-        entry = _entry_from_env(_parse_env_file(root_env_path))
+        entry = build_entry(_parse_env_file(root_env_path))
         if entry:
-            registry[ROOT_PROFILE_AGENT_ID] = _merge_with_existing(
-                entry, prior.get(ROOT_PROFILE_AGENT_ID)
+            registry_agents[ROOT_PROFILE_AGENT_ID] = _merge_with_existing(
+                entry, prior_agents.get(ROOT_PROFILE_AGENT_ID)
             )
 
     # One entry per profile subdirectory
@@ -337,19 +401,52 @@ def wake_registry_init(
         env_path = profile_dir / ".env"
         if not env_path.is_file():
             continue
-        entry = _entry_from_env(_parse_env_file(env_path))
+        entry = build_entry(_parse_env_file(env_path))
         if not entry:
             continue
         agent_id = f"{AGENT_ID_PREFIX}{profile_dir.name}"
         if not AGENT_ID_PATTERN.match(agent_id):
             console.print(f"[yellow]skip[/yellow] {agent_id} (invalid id)")
             continue
-        registry[agent_id] = _merge_with_existing(entry, prior.get(agent_id))
+        registry_agents[agent_id] = _merge_with_existing(
+            entry, prior_agents.get(agent_id)
+        )
+
+    # Resolve the shared wake-bot token (new format only).
+    shared_token: str | None = None
+    if not legacy_format:
+        wake_bot_env = profiles_root / wake_bot_profile / ".env"
+        if wake_bot_env.is_file():
+            parsed = _parse_env_file(wake_bot_env)
+            candidate = parsed.get("TELEGRAM_BOT_TOKEN", "").strip()
+            if candidate:
+                shared_token = candidate
+        # Fallback: reuse the one we had in the prior registry (if any).
+        if not shared_token and prior_shared_token:
+            shared_token = prior_shared_token
+            console.print(
+                f"[yellow]reused wake_bot_token from prior registry[/yellow] "
+                f"(profile '{wake_bot_profile}' has no TELEGRAM_BOT_TOKEN)"
+            )
+
+    # Compose the final payload.
+    if legacy_format:
+        payload: dict[str, Any] = dict(registry_agents)
+    else:
+        if not shared_token:
+            console.print(
+                f"[red]error:[/red] could not resolve a wake-bot token from "
+                f"profile '{wake_bot_profile}' (and no prior registry with one). "
+                f"Either populate {wake_bot_profile}/.env with TELEGRAM_BOT_TOKEN "
+                f"or re-run with --legacy-format."
+            )
+            raise typer.Exit(code=3)
+        payload = {"wake_bot_token": shared_token, "agents": registry_agents}
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    if not registry:
+    if not registry_agents:
         console.print(
             f"[yellow]No wake entries found — wrote empty registry to {out_path}[/yellow]"
         )
@@ -357,13 +454,16 @@ def wake_registry_init(
 
     # Report how many thread_id overrides were preserved so operators notice
     # when a merge actually did something useful.
-    preserved = sum(1 for e in registry.values() if "thread_id" in e)
+    preserved = sum(1 for e in registry_agents.values() if "thread_id" in e)
 
-    table = Table(title=f"Wake registry ({len(registry)} agent(s)) → {out_path}")
+    title_mode = "legacy per-agent" if legacy_format else f"shared-bot ({wake_bot_profile})"
+    table = Table(
+        title=f"Wake registry ({len(registry_agents)} agent(s), {title_mode}) → {out_path}"
+    )
     table.add_column("agent_id")
     table.add_column("chat_id")
     table.add_column("thread_id")
-    for aid, entry in registry.items():
+    for aid, entry in registry_agents.items():
         tid = entry.get("thread_id")
         table.add_row(aid, str(entry["chat_id"]), "—" if tid is None else str(tid))
     console.print(table)

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -88,14 +88,19 @@ def _load_waker() -> TelegramWaker | None:
     """
     path = _resolve_wake_registry_path()
     try:
-        registry = load_registry(path)
+        shared_token, registry = load_registry(path)
     except ValueError as exc:
         logger.warning("wake registry %s is malformed, disabling wake-up: %s", path, exc)
         return None
     if not registry:
         return None
-    logger.info("wake registry loaded: %d agent(s) from %s", len(registry), path)
-    return TelegramWaker(registry)
+    logger.info(
+        "wake registry loaded: %d agent(s) from %s (mode=%s)",
+        len(registry),
+        path,
+        "shared-bot" if shared_token else "per-agent",
+    )
+    return TelegramWaker(registry, shared_token=shared_token)
 
 
 class A2AMcp(FastMCP):

--- a/src/a2a_mcp_bridge/wake.py
+++ b/src/a2a_mcp_bridge/wake.py
@@ -1,8 +1,8 @@
-"""Telegram wake-up layer for a2a-mcp-bridge (v0.3).
+"""Telegram wake-up layer for a2a-mcp-bridge.
 
 When an agent receives a message via ``agent_send``, we optionally send a short
-Telegram notification to the recipient's bot so the recipient's gateway wakes
-up and the agent gets a chance to process its inbox.
+Telegram notification to the recipient so the recipient's gateway wakes up and
+the agent gets a chance to process its inbox.
 
 This is a **best-effort** optimisation, just like the signal files:
 
@@ -13,24 +13,34 @@ This is a **best-effort** optimisation, just like the signal files:
 The canonical record of a message is still the SQLite store. Failing to wake
 the recipient must never prevent ``agent_send`` from storing the message.
 
-Registry format (JSON file, default ``~/.a2a-wake-registry.json``)::
+Registry format (JSON file, default ``~/.a2a-wake-registry.json``).
+
+**Preferred format (v0.4.3+) — single shared bot**::
 
     {
-        "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "1395012867"},
-        "vlbeau-glm51": {"bot_token": "123:ABC", "chat_id": "1395012867"}
+        "wake_bot_token": "123:ABC",
+        "agents": {
+            "vlbeau-main":  {"chat_id": "-1001234567890", "thread_id": 5},
+            "vlbeau-glm51": {"chat_id": "-1001234567890", "thread_id": 7}
+        }
     }
 
-Optional ``thread_id`` (v0.4.2) routes the wake-up to a specific forum topic
-in a Telegram supergroup — useful when all agents share one supergroup but
-each deserves its own topic to avoid wake-up crosstalk::
+A **single "wake bot"** token is used to POST every wake-up. In a Telegram
+supergroup with forum topics this is required: a bot does not receive its
+own messages, so a self-posted wake-up never reaches the bot's gateway.
+Posting via a neutral bot (typically ``@VLBeauBot`` / ``vlbeau-main``)
+gives the recipient's bot an actual incoming Telegram update, which is
+what the Hermes gateway listens for.
+
+**Legacy format (v0.3 - v0.4.2) — per-agent token**::
 
     {
-        "vlbeau-main":  {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 5},
-        "vlbeau-glm51": {"bot_token": "123:ABC", "chat_id": "-1001234567890", "thread_id": 7}
+        "vlbeau-main":  {"bot_token": "111:...", "chat_id": "1395012867"},
+        "vlbeau-glm51": {"bot_token": "222:...", "chat_id": "1395012867", "thread_id": 7}
     }
 
-Entries without ``thread_id`` keep the v0.4.1 behaviour (plain DM or group
-``General`` topic).
+Still accepted transparently; each wake-up is POSTed via the recipient's
+own ``bot_token``. A warning is logged to encourage migration.
 """
 
 from __future__ import annotations
@@ -54,10 +64,12 @@ DEFAULT_TIMEOUT_SECONDS = 5.0
 class WakeEntry:
     """One recipient's Telegram delivery details.
 
-    ``thread_id`` is optional (v0.4.2+): when set, the wake-up is routed to
-    the given forum topic in a Telegram supergroup via the
-    ``message_thread_id`` parameter of the sendMessage API. Absent / ``None``
-    falls back to the default chat target (DM or ``General`` topic).
+    ``bot_token`` is the legacy per-agent token (v0.3 - v0.4.2). In the
+    v0.4.3+ shared-wake-bot format it is an empty string and the waker
+    uses ``TelegramWaker.shared_token`` instead.
+
+    ``thread_id`` is optional: when set, the wake-up is routed to the given
+    forum topic via Telegram's ``message_thread_id`` parameter.
     """
 
     bot_token: str
@@ -65,16 +77,59 @@ class WakeEntry:
     thread_id: int | None = None
 
 
-def load_registry(path: str) -> dict[str, WakeEntry]:
-    """Load the JSON wake registry from ``path``.
+def _parse_entry(agent_id: str, entry: Any, *, require_token: bool) -> WakeEntry:
+    """Validate and coerce a single registry entry into a :class:`WakeEntry`."""
+    if not isinstance(entry, dict):
+        raise ValueError(f"wake registry entry for {agent_id!r} must be an object")
 
-    Returns an empty dict if the file does not exist (lets the caller treat
-    wake-up as opt-in without extra plumbing). Raises :class:`ValueError` if
-    the file exists but is malformed.
+    if require_token:
+        token = entry.get("bot_token")
+        if not isinstance(token, str) or not token:
+            raise ValueError(
+                f"wake registry entry for {agent_id!r} is missing a string 'bot_token'"
+            )
+    else:
+        # Shared-wake-bot format: per-agent token is not used.
+        token = ""
+
+    chat_id = entry.get("chat_id")
+    if not isinstance(chat_id, str) or not chat_id:
+        raise ValueError(
+            f"wake registry entry for {agent_id!r} is missing a string 'chat_id'"
+        )
+
+    # thread_id lives under "thread_id" (preferred, shorter) but we also
+    # accept "message_thread_id" because that is the Telegram Bot API name
+    # and some operators will type it by reflex.
+    thread_id = entry.get("thread_id")
+    if thread_id is None:
+        thread_id = entry.get("message_thread_id")
+    if thread_id is not None and (
+        not isinstance(thread_id, int) or isinstance(thread_id, bool)
+    ):
+        raise ValueError(
+            f"wake registry entry for {agent_id!r} has a non-integer 'thread_id'"
+        )
+
+    return WakeEntry(bot_token=token, chat_id=chat_id, thread_id=thread_id)
+
+
+def load_registry(path: str) -> tuple[str | None, dict[str, WakeEntry]]:
+    """Load the wake registry from ``path``.
+
+    Returns a ``(shared_token, entries)`` tuple:
+
+    * ``shared_token`` is the shared wake-bot token (v0.4.3+ format) or
+      ``None`` when the legacy per-agent-token format is in use.
+    * ``entries`` maps ``agent_id`` to its :class:`WakeEntry`.
+
+    A missing file returns ``(None, {})`` so callers can treat wake-up as
+    opt-in. A malformed file raises :class:`ValueError`.
     """
     p = Path(path)
     if not p.is_file():
-        return {}
+        return None, {}
+
     try:
         raw: Any = json.loads(p.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -83,25 +138,43 @@ def load_registry(path: str) -> dict[str, WakeEntry]:
     if not isinstance(raw, dict):
         raise ValueError(f"wake registry {path} must be a JSON object at top level")
 
-    registry: dict[str, WakeEntry] = {}
+    entries: dict[str, WakeEntry] = {}
+
+    # Detect format: v0.4.3+ has top-level "wake_bot_token" + "agents" dict.
+    shared_token = raw.get("wake_bot_token")
+    if shared_token is not None:
+        if not isinstance(shared_token, str) or not shared_token:
+            raise ValueError(
+                f"wake registry {path}: 'wake_bot_token' must be a non-empty string"
+            )
+        agents_raw = raw.get("agents")
+        if not isinstance(agents_raw, dict):
+            raise ValueError(
+                f"wake registry {path}: 'agents' must be an object when "
+                f"'wake_bot_token' is set"
+            )
+        for agent_id, entry in agents_raw.items():
+            entries[agent_id] = _parse_entry(
+                agent_id, entry, require_token=False
+            )
+        return shared_token, entries
+
+    # Legacy format (v0.3 - v0.4.2): each entry carries its own bot_token.
+    # Accepted for backward compatibility but logged as deprecated.
+    legacy_keys_present = any(
+        isinstance(v, dict) and "bot_token" in v for v in raw.values()
+    )
+    if legacy_keys_present:
+        logger.warning(
+            "wake registry %s uses the legacy per-agent bot_token format; "
+            "consider migrating to the shared-wake-bot format (v0.4.3+) so "
+            "that Telegram supergroups with forum topics work correctly. "
+            "Run `a2a-mcp-bridge wake-registry init` to regenerate.",
+            path,
+        )
     for agent_id, entry in raw.items():
-        if not isinstance(entry, dict):
-            raise ValueError(f"wake registry entry for {agent_id!r} must be an object")
-        token = entry.get("bot_token")
-        chat_id = entry.get("chat_id")
-        if not isinstance(token, str) or not token:
-            raise ValueError(
-                f"wake registry entry for {agent_id!r} is missing a string 'bot_token'"
-            )
-        if not isinstance(chat_id, str) or not chat_id:
-            raise ValueError(f"wake registry entry for {agent_id!r} is missing a string 'chat_id'")
-        thread_id = entry.get("thread_id")
-        if thread_id is not None and (not isinstance(thread_id, int) or isinstance(thread_id, bool)):
-            raise ValueError(
-                f"wake registry entry for {agent_id!r} has a non-integer 'thread_id'"
-            )
-        registry[agent_id] = WakeEntry(bot_token=token, chat_id=chat_id, thread_id=thread_id)
-    return registry
+        entries[agent_id] = _parse_entry(agent_id, entry, require_token=True)
+    return None, entries
 
 
 def _format_message(sender_id: str) -> str:
@@ -120,15 +193,27 @@ def _format_message(sender_id: str) -> str:
 
 
 class TelegramWaker:
-    """Best-effort Telegram notifier, keyed by recipient agent_id."""
+    """Best-effort Telegram notifier, keyed by recipient agent_id.
+
+    In the v0.4.3+ shared-wake-bot format, every wake-up is POSTed using
+    ``shared_token``. In the legacy format, each recipient's
+    ``WakeEntry.bot_token`` is used.
+
+    Self-wake (``agent_id == sender_id``) is skipped unconditionally: an
+    agent sending a message to itself would otherwise trigger a wake-up
+    loop on the same gateway.
+    """
 
     def __init__(
         self,
         registry: dict[str, WakeEntry],
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        *,
+        shared_token: str | None = None,
     ) -> None:
         self._registry = registry
         self._timeout = timeout_seconds
+        self._shared_token = shared_token
 
     def has(self, agent_id: str) -> bool:
         return agent_id in self._registry
@@ -136,27 +221,48 @@ class TelegramWaker:
     def __len__(self) -> int:
         return len(self._registry)
 
+    @property
+    def uses_shared_token(self) -> bool:
+        """Whether this waker posts every wake-up via a single shared bot."""
+        return self._shared_token is not None
+
     def wake(self, agent_id: str, sender_id: str) -> bool:
         """Send a wake-up Telegram message to ``agent_id``'s registered bot.
 
         Returns ``True`` on HTTP 2xx, ``False`` on any other outcome (unknown
-        agent, HTTP error, network error, unexpected exception). Never raises.
+        agent, self-wake skip, HTTP error, network error, unexpected
+        exception). Never raises.
         """
+        if agent_id == sender_id:
+            # An agent waking itself is almost certainly a bug upstream — skip
+            # silently rather than risk a wake-loop on the same gateway.
+            logger.debug("wake skipped: sender == target (%s)", agent_id)
+            return False
+
         entry = self._registry.get(agent_id)
         if entry is None:
             logger.debug("wake skipped: %s not in registry", agent_id)
             return False
 
-        url = f"{TELEGRAM_API_BASE}/bot{entry.bot_token}/sendMessage"
+        # Pick the token: shared (v0.4.3+) wins over per-agent (legacy).
+        token = self._shared_token if self._shared_token else entry.bot_token
+        if not token:
+            logger.debug(
+                "wake skipped: %s has no bot_token and no shared token is set",
+                agent_id,
+            )
+            return False
+
+        url = f"{TELEGRAM_API_BASE}/bot{token}/sendMessage"
         params: dict[str, str] = {
             "chat_id": entry.chat_id,
             "text": _format_message(sender_id),
             "disable_notification": "false",
         }
         if entry.thread_id is not None:
-            # Forum topic routing (Telegram Bot API field name is
-            # ``message_thread_id``; we keep ``thread_id`` in the registry for
-            # ergonomics).
+            # Forum topic routing. Telegram's Bot API field is
+            # ``message_thread_id``; we keep ``thread_id`` in the registry
+            # for ergonomics.
             params["message_thread_id"] = str(entry.thread_id)
         payload = urlencode(params).encode("utf-8")
         req = Request(

--- a/tests/test_cli_wake_registry.py
+++ b/tests/test_cli_wake_registry.py
@@ -1,4 +1,4 @@
-"""Tests for the `wake-registry` CLI commands (v0.3)."""
+"""Tests for the ``wake-registry`` CLI commands."""
 
 from __future__ import annotations
 
@@ -19,27 +19,26 @@ def _write_env(path: Path, **values: str) -> None:
     )
 
 
-def test_wake_registry_init_builds_registry_from_hermes(tmp_path: Path) -> None:
-    """`wake-registry init` must scan profiles and produce a correct JSON map."""
+# --------------------------------------------------------------------------- #
+# Default: v0.4.3+ shared-wake-bot format
+# --------------------------------------------------------------------------- #
+
+
+def test_wake_registry_init_defaults_to_shared_bot_format(tmp_path: Path) -> None:
+    """``init`` without flags must emit the shared-wake-bot JSON shape."""
     hermes = tmp_path / ".hermes"
     profiles = hermes / "profiles"
     (profiles / "main").mkdir(parents=True)
     (profiles / "glm51").mkdir()
     _write_env(
         profiles / "main" / ".env",
-        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_BOT_TOKEN="111:MAIN_WAKE_BOT",
         TELEGRAM_HOME_CHANNEL="1000",
     )
     _write_env(
         profiles / "glm51" / ".env",
-        TELEGRAM_BOT_TOKEN="222:GLM",
+        TELEGRAM_BOT_TOKEN="222:GLM",  # should be dropped in new format
         TELEGRAM_HOME_CHANNEL="2000",
-    )
-    # Root .env → vlbeau-opus (root profile convention)
-    _write_env(
-        hermes / ".env",
-        TELEGRAM_BOT_TOKEN="333:OPUS",
-        TELEGRAM_HOME_CHANNEL="3000",
     )
 
     out = tmp_path / "wake.json"
@@ -57,13 +56,163 @@ def test_wake_registry_init_builds_registry_from_hermes(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert reg["vlbeau-main"] == {"bot_token": "111:MAIN", "chat_id": "1000"}
-    assert reg["vlbeau-glm51"] == {"bot_token": "222:GLM", "chat_id": "2000"}
-    assert reg["vlbeau-opus"] == {"bot_token": "333:OPUS", "chat_id": "3000"}
+
+    payload = json.loads(out.read_text())
+    # Top-level shape
+    assert payload["wake_bot_token"] == "111:MAIN_WAKE_BOT"
+    assert "agents" in payload
+    # Per-agent entries: chat_id yes, bot_token no
+    assert payload["agents"]["vlbeau-main"] == {"chat_id": "1000"}
+    assert payload["agents"]["vlbeau-glm51"] == {"chat_id": "2000"}
+    assert "bot_token" not in payload["agents"]["vlbeau-glm51"]
 
 
-def test_wake_registry_init_skips_profile_missing_env(tmp_path: Path) -> None:
+def test_wake_registry_init_uses_custom_wake_bot_profile(tmp_path: Path) -> None:
+    """``--wake-bot-profile <name>`` sources the token from that profile."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    (profiles / "opus").mkdir()
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+    _write_env(
+        profiles / "opus" / ".env",
+        TELEGRAM_BOT_TOKEN="999:OPUS_AS_WAKE_BOT",
+        TELEGRAM_HOME_CHANNEL="9000",
+    )
+
+    out = tmp_path / "wake.json"
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+            "--wake-bot-profile",
+            "opus",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+    assert payload["wake_bot_token"] == "999:OPUS_AS_WAKE_BOT"
+
+
+def test_wake_registry_init_errors_when_wake_bot_token_missing(tmp_path: Path) -> None:
+    """No wake-bot token + no prior registry ⇒ hard error (not silent)."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    # main has a channel but NO bot token — broken config
+    _write_env(profiles / "main" / ".env", TELEGRAM_HOME_CHANNEL="1000")
+
+    out = tmp_path / "wake.json"
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code != 0, result.stdout
+    assert "wake-bot token" in result.stdout.lower()
+
+
+def test_wake_registry_init_reuses_prior_wake_bot_token(tmp_path: Path) -> None:
+    """If the profile's .env has no token but the prior registry has one,
+    ``init`` must reuse it instead of erroring out."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    # No TELEGRAM_BOT_TOKEN in main.env
+    _write_env(profiles / "main" / ".env", TELEGRAM_HOME_CHANNEL="1000")
+
+    out = tmp_path / "wake.json"
+    # Seed a prior registry with a shared token
+    out.write_text(
+        json.dumps(
+            {"wake_bot_token": "PRIOR:TOKEN", "agents": {}}
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+    assert payload["wake_bot_token"] == "PRIOR:TOKEN"
+    assert payload["agents"]["vlbeau-main"]["chat_id"] == "1000"
+
+
+def test_wake_registry_init_preserves_thread_id_across_regenerations(
+    tmp_path: Path,
+) -> None:
+    """thread_id overrides must survive re-init, even with the new format."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:NEW",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+
+    out = tmp_path / "wake.json"
+    # Seed a prior registry with a thread_id on main
+    out.write_text(
+        json.dumps(
+            {
+                "wake_bot_token": "111:OLD",
+                "agents": {
+                    "vlbeau-main": {"chat_id": "1000", "thread_id": 42}
+                },
+            }
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+    # Token refreshed, thread_id preserved
+    assert payload["wake_bot_token"] == "111:NEW"
+    assert payload["agents"]["vlbeau-main"]["thread_id"] == 42
+
+
+def test_wake_registry_init_migrates_legacy_prior_registry(tmp_path: Path) -> None:
+    """A prior legacy-format registry must be silently upgraded to shared-bot."""
     hermes = tmp_path / ".hermes"
     profiles = hermes / "profiles"
     (profiles / "main").mkdir(parents=True)
@@ -72,7 +221,53 @@ def test_wake_registry_init_skips_profile_missing_env(tmp_path: Path) -> None:
         TELEGRAM_BOT_TOKEN="111:MAIN",
         TELEGRAM_HOME_CHANNEL="1000",
     )
-    # glm51 has no .env → must be skipped, not crash
+
+    out = tmp_path / "wake.json"
+    # Legacy-format prior registry (no wake_bot_token at top level)
+    out.write_text(
+        json.dumps(
+            {
+                "vlbeau-main": {
+                    "bot_token": "LEGACY_IGNORE",
+                    "chat_id": "1000",
+                    "thread_id": 7,
+                }
+            }
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+    # Now in new format
+    assert payload["wake_bot_token"] == "111:MAIN"
+    # thread_id preserved even from legacy shape
+    assert payload["agents"]["vlbeau-main"]["thread_id"] == 7
+    # per-agent bot_token gone
+    assert "bot_token" not in payload["agents"]["vlbeau-main"]
+
+
+def test_wake_registry_init_skips_profile_missing_channel(tmp_path: Path) -> None:
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+    # glm51 has no .env → skipped
     (profiles / "glm51").mkdir()
 
     out = tmp_path / "wake.json"
@@ -90,16 +285,17 @@ def test_wake_registry_init_skips_profile_missing_env(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert "vlbeau-main" in reg
-    assert "vlbeau-glm51" not in reg
+    payload = json.loads(out.read_text())
+    assert "vlbeau-main" in payload["agents"]
+    assert "vlbeau-glm51" not in payload["agents"]
 
 
-def test_wake_registry_init_skips_env_missing_required_keys(tmp_path: Path) -> None:
+def test_wake_registry_init_empty_result(tmp_path: Path) -> None:
+    """No profile has a channel → registry is empty but command succeeds."""
     hermes = tmp_path / ".hermes"
     profiles = hermes / "profiles"
     (profiles / "main").mkdir(parents=True)
-    # Only one of the two required variables → skip
+    # main only has the wake-bot token — no TELEGRAM_HOME_CHANNEL → entry skipped
     _write_env(profiles / "main" / ".env", TELEGRAM_BOT_TOKEN="111:MAIN")
 
     out = tmp_path / "wake.json"
@@ -117,51 +313,9 @@ def test_wake_registry_init_skips_env_missing_required_keys(tmp_path: Path) -> N
         ],
     )
     assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert "vlbeau-main" not in reg
-
-
-def test_wake_registry_init_empty_result(tmp_path: Path) -> None:
-    hermes = tmp_path / ".hermes"
-    profiles = hermes / "profiles"
-    profiles.mkdir(parents=True)
-    out = tmp_path / "wake.json"
-    result = runner.invoke(
-        app,
-        [
-            "wake-registry",
-            "init",
-            "--hermes-profiles",
-            str(profiles),
-            "--hermes-root",
-            str(hermes),
-            "--output",
-            str(out),
-        ],
-    )
-    assert result.exit_code == 0
-    # Empty registry file is still written
-    assert out.is_file()
-    assert json.loads(out.read_text()) == {}
-
-
-def test_wake_registry_init_missing_profiles_dir(tmp_path: Path) -> None:
-    out = tmp_path / "wake.json"
-    result = runner.invoke(
-        app,
-        [
-            "wake-registry",
-            "init",
-            "--hermes-profiles",
-            str(tmp_path / "nope"),
-            "--hermes-root",
-            str(tmp_path),
-            "--output",
-            str(out),
-        ],
-    )
-    assert result.exit_code != 0
-    assert not out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["wake_bot_token"] == "111:MAIN"
+    assert payload["agents"] == {}
 
 
 def test_wake_registry_init_handles_quoted_values(tmp_path: Path) -> None:
@@ -170,7 +324,8 @@ def test_wake_registry_init_handles_quoted_values(tmp_path: Path) -> None:
     profiles = hermes / "profiles"
     (profiles / "main").mkdir(parents=True)
     (profiles / "main" / ".env").write_text(
-        "TELEGRAM_BOT_TOKEN=\"111:MAIN\"\nTELEGRAM_HOME_CHANNEL='1000'\n",
+        'TELEGRAM_BOT_TOKEN="111:QUOTED"\n'
+        'TELEGRAM_HOME_CHANNEL="1000"\n',
         encoding="utf-8",
     )
     out = tmp_path / "wake.json"
@@ -188,104 +343,13 @@ def test_wake_registry_init_handles_quoted_values(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert reg["vlbeau-main"] == {"bot_token": "111:MAIN", "chat_id": "1000"}
-
-
-# --------------------------------------------------------------------------- #
-# v0.4.2: thread_id preservation on re-init (approach "a" — intelligent merge)
-# --------------------------------------------------------------------------- #
-
-
-def test_wake_registry_init_preserves_thread_id_from_prior(tmp_path: Path) -> None:
-    """Re-running ``init`` must not wipe manually-added ``thread_id`` fields.
-
-    The operator typically adds ``thread_id`` (+ supergroup ``chat_id``) by
-    editing the JSON after the first ``init``. A second ``init`` must rebuild
-    ``bot_token`` from the latest Hermes ``.env`` while carrying the existing
-    ``thread_id`` forward — the source of truth for topic routing is the
-    registry, not the env.
-    """
-    hermes = tmp_path / ".hermes"
-    profiles = hermes / "profiles"
-    (profiles / "main").mkdir(parents=True)
-    _write_env(
-        profiles / "main" / ".env",
-        TELEGRAM_BOT_TOKEN="111:NEW",
-        TELEGRAM_HOME_CHANNEL="1000",
-    )
-
-    out = tmp_path / "wake.json"
-    # Seed a prior registry with thread_id
-    out.write_text(
-        json.dumps(
-            {
-                "vlbeau-main": {
-                    "bot_token": "111:OLD",
-                    "chat_id": "1000",
-                    "thread_id": 42,
-                }
-            }
-        )
-    )
-
-    result = runner.invoke(
-        app,
-        [
-            "wake-registry",
-            "init",
-            "--hermes-profiles",
-            str(profiles),
-            "--hermes-root",
-            str(hermes),
-            "--output",
-            str(out),
-        ],
-    )
-    assert result.exit_code == 0, result.stdout
-
-    reg = json.loads(out.read_text())
-    entry = reg["vlbeau-main"]
-    # bot_token refreshed from .env, but thread_id preserved from prior
-    assert entry["bot_token"] == "111:NEW"
-    assert entry["thread_id"] == 42
-
-
-def test_wake_registry_init_adds_no_thread_id_when_prior_has_none(
-    tmp_path: Path,
-) -> None:
-    """First-run baseline: without a prior registry, entries lack ``thread_id``."""
-    hermes = tmp_path / ".hermes"
-    profiles = hermes / "profiles"
-    (profiles / "main").mkdir(parents=True)
-    _write_env(
-        profiles / "main" / ".env",
-        TELEGRAM_BOT_TOKEN="111:MAIN",
-        TELEGRAM_HOME_CHANNEL="1000",
-    )
-
-    out = tmp_path / "wake.json"
-    result = runner.invoke(
-        app,
-        [
-            "wake-registry",
-            "init",
-            "--hermes-profiles",
-            str(profiles),
-            "--hermes-root",
-            str(hermes),
-            "--output",
-            str(out),
-        ],
-    )
-    assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert "thread_id" not in reg["vlbeau-main"]
+    payload = json.loads(out.read_text())
+    assert payload["wake_bot_token"] == "111:QUOTED"
+    assert payload["agents"]["vlbeau-main"]["chat_id"] == "1000"
 
 
 def test_wake_registry_init_ignores_corrupt_prior(tmp_path: Path) -> None:
-    """A malformed prior registry must not prevent regeneration — init is
-    meant to be idempotent and recoverable."""
+    """A malformed prior registry must not prevent regeneration."""
     hermes = tmp_path / ".hermes"
     profiles = hermes / "profiles"
     (profiles / "main").mkdir(parents=True)
@@ -311,7 +375,43 @@ def test_wake_registry_init_ignores_corrupt_prior(tmp_path: Path) -> None:
             str(out),
         ],
     )
-    # Must still succeed, overwriting the corrupt file
     assert result.exit_code == 0, result.stdout
-    reg = json.loads(out.read_text())
-    assert reg["vlbeau-main"]["bot_token"] == "111:MAIN"
+    payload = json.loads(out.read_text())
+    assert payload["wake_bot_token"] == "111:MAIN"
+
+
+# --------------------------------------------------------------------------- #
+# --legacy-format flag for operators who need per-agent-token DMs
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_format_emits_old_shape(tmp_path: Path) -> None:
+    """``--legacy-format`` produces the v0.3 - v0.4.2 JSON shape."""
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+    out = tmp_path / "wake.json"
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+            "--legacy-format",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+    # Legacy shape: no top-level wake_bot_token, entries carry bot_token
+    assert "wake_bot_token" not in payload
+    assert payload["vlbeau-main"] == {"bot_token": "111:MAIN", "chat_id": "1000"}

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -1,4 +1,4 @@
-"""Tests for the Telegram wake-up layer (v0.3)."""
+"""Tests for the Telegram wake-up layer."""
 
 from __future__ import annotations
 
@@ -12,11 +12,13 @@ import pytest
 from a2a_mcp_bridge.wake import TelegramWaker, WakeEntry, load_registry
 
 # --------------------------------------------------------------------------- #
-# load_registry
+# load_registry — legacy format (per-agent bot_token)
 # --------------------------------------------------------------------------- #
 
 
-class TestLoadRegistry:
+class TestLoadRegistryLegacy:
+    """The v0.3 - v0.4.2 format: one bot_token per entry, no top-level keys."""
+
     def test_loads_valid_json(self, tmp_path: Path) -> None:
         path = tmp_path / "reg.json"
         path.write_text(
@@ -27,13 +29,17 @@ class TestLoadRegistry:
                 }
             )
         )
-        reg = load_registry(str(path))
+        shared, reg = load_registry(str(path))
+        # Legacy format: no shared token is returned.
+        assert shared is None
         assert reg["vlbeau-main"].bot_token == "abc:def"
         assert reg["vlbeau-main"].chat_id == "123"
         assert reg["vlbeau-glm51"].chat_id == "456"
 
     def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
-        assert load_registry(str(tmp_path / "nope.json")) == {}
+        shared, reg = load_registry(str(tmp_path / "nope.json"))
+        assert shared is None
+        assert reg == {}
 
     def test_malformed_json_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "bad.json"
@@ -59,10 +65,9 @@ class TestLoadRegistry:
         with pytest.raises(ValueError):
             load_registry(str(path))
 
-    # ----- v0.4.2: optional thread_id for forum-topic routing --------------- #
+    # ----- v0.4.2: optional thread_id in legacy entries --------------------- #
 
     def test_loads_entry_with_thread_id(self, tmp_path: Path) -> None:
-        """Registry entries MAY carry a ``thread_id`` int for forum topics."""
         path = tmp_path / "reg.json"
         path.write_text(
             json.dumps(
@@ -75,7 +80,7 @@ class TestLoadRegistry:
                 }
             )
         )
-        reg = load_registry(str(path))
+        _, reg = load_registry(str(path))
         assert reg["vlbeau-main"].thread_id == 5
 
     def test_thread_id_is_optional_backwards_compatible(self, tmp_path: Path) -> None:
@@ -84,11 +89,10 @@ class TestLoadRegistry:
         path.write_text(
             json.dumps({"vlbeau-main": {"bot_token": "T:TOKEN", "chat_id": "123"}})
         )
-        reg = load_registry(str(path))
+        _, reg = load_registry(str(path))
         assert reg["vlbeau-main"].thread_id is None
 
     def test_non_integer_thread_id_raises(self, tmp_path: Path) -> None:
-        """``thread_id`` MUST be an int (or absent); anything else is a typo."""
         path = tmp_path / "bad.json"
         path.write_text(
             json.dumps(
@@ -109,9 +113,118 @@ class TestLoadRegistry:
         with pytest.raises(ValueError, match="thread_id"):
             load_registry(str(path))
 
+    def test_legacy_format_warns_about_migration(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Legacy format is accepted but logs a deprecation warning."""
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps({"vlbeau-main": {"bot_token": "T:TOK", "chat_id": "123"}})
+        )
+        with caplog.at_level("WARNING", logger="a2a_mcp_bridge.wake"):
+            load_registry(str(path))
+        assert any(
+            "legacy per-agent bot_token format" in r.message for r in caplog.records
+        )
+
 
 # --------------------------------------------------------------------------- #
-# TelegramWaker.wake
+# load_registry — shared-wake-bot format (v0.4.3+)
+# --------------------------------------------------------------------------- #
+
+
+class TestLoadRegistrySharedBot:
+    """The v0.4.3+ format: a top-level ``wake_bot_token`` + ``agents`` dict."""
+
+    def test_loads_shared_bot_format(self, tmp_path: Path) -> None:
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "wake_bot_token": "SHARED:TOKEN",
+                    "agents": {
+                        "vlbeau-main": {"chat_id": "-100111", "thread_id": 5},
+                        "vlbeau-glm51": {"chat_id": "-100111", "thread_id": 7},
+                    },
+                }
+            )
+        )
+        shared, reg = load_registry(str(path))
+        assert shared == "SHARED:TOKEN"
+        # Each entry stores chat_id + thread_id; per-agent bot_token is empty.
+        assert reg["vlbeau-main"].chat_id == "-100111"
+        assert reg["vlbeau-main"].thread_id == 5
+        assert reg["vlbeau-main"].bot_token == ""
+        assert reg["vlbeau-glm51"].thread_id == 7
+
+    def test_shared_bot_requires_non_empty_token(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps({"wake_bot_token": "", "agents": {}})
+        )
+        with pytest.raises(ValueError, match="wake_bot_token"):
+            load_registry(str(path))
+
+    def test_shared_bot_requires_agents_dict(self, tmp_path: Path) -> None:
+        """If ``wake_bot_token`` is set, ``agents`` must be an object."""
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps({"wake_bot_token": "T:TOK", "agents": "not a dict"})
+        )
+        with pytest.raises(ValueError, match="agents"):
+            load_registry(str(path))
+
+    def test_shared_bot_entry_requires_chat_id(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps(
+                {"wake_bot_token": "T:TOK", "agents": {"vlbeau-main": {"thread_id": 5}}}
+            )
+        )
+        with pytest.raises(ValueError, match="chat_id"):
+            load_registry(str(path))
+
+    def test_shared_bot_entry_accepts_message_thread_id_alias(
+        self, tmp_path: Path
+    ) -> None:
+        """Operators typing the Telegram-native field name should still work."""
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "wake_bot_token": "T:TOK",
+                    "agents": {
+                        "vlbeau-main": {
+                            "chat_id": "-100111",
+                            "message_thread_id": 42,
+                        }
+                    },
+                }
+            )
+        )
+        _, reg = load_registry(str(path))
+        assert reg["vlbeau-main"].thread_id == 42
+
+    def test_shared_bot_does_not_warn_about_legacy(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The new format must NOT trigger the legacy-migration warning."""
+        path = tmp_path / "reg.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "wake_bot_token": "T:TOK",
+                    "agents": {"vlbeau-main": {"chat_id": "-100111"}},
+                }
+            )
+        )
+        with caplog.at_level("WARNING", logger="a2a_mcp_bridge.wake"):
+            load_registry(str(path))
+        assert not any("legacy" in r.message.lower() for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# TelegramWaker.wake — legacy mode (per-agent token)
 # --------------------------------------------------------------------------- #
 
 
@@ -122,8 +235,10 @@ def waker_registry() -> dict[str, WakeEntry]:
     }
 
 
-class TestTelegramWakerWake:
-    def test_wake_posts_to_sendmessage_endpoint(self, waker_registry: dict[str, WakeEntry]) -> None:
+class TestTelegramWakerLegacy:
+    def test_wake_posts_to_sendmessage_endpoint(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
         waker = TelegramWaker(waker_registry)
         fake_response = MagicMock()
         fake_response.__enter__.return_value = fake_response
@@ -136,10 +251,9 @@ class TestTelegramWakerWake:
         assert ok is True
         assert up.call_count == 1
         request_obj = up.call_args.args[0]
-        # URL must target the correct bot token
+        # URL must target the legacy per-agent token
         assert "T:TOKEN" in request_obj.full_url
         assert request_obj.full_url.endswith("/sendMessage")
-        # Body is form-urlencoded with chat_id + text
         body = request_obj.data.decode("utf-8")
         assert "chat_id=999" in body
         assert "vlbeau-glm51" in body  # sender name mentioned
@@ -158,7 +272,9 @@ class TestTelegramWakerWake:
             assert waker.wake("anything", sender_id="alice") is False
         up.assert_not_called()
 
-    def test_wake_swallows_http_errors(self, waker_registry: dict[str, WakeEntry]) -> None:
+    def test_wake_swallows_http_errors(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
         waker = TelegramWaker(waker_registry)
         with patch(
             "a2a_mcp_bridge.wake.urlopen",
@@ -166,7 +282,9 @@ class TestTelegramWakerWake:
         ):
             assert waker.wake("vlbeau-main", sender_id="a") is False
 
-    def test_wake_swallows_network_errors(self, waker_registry: dict[str, WakeEntry]) -> None:
+    def test_wake_swallows_network_errors(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
         waker = TelegramWaker(waker_registry)
         with patch("a2a_mcp_bridge.wake.urlopen", side_effect=URLError("network down")):
             assert waker.wake("vlbeau-main", sender_id="a") is False
@@ -174,13 +292,13 @@ class TestTelegramWakerWake:
     def test_wake_swallows_unexpected_exceptions(
         self, waker_registry: dict[str, WakeEntry]
     ) -> None:
-        """Unexpected errors must not propagate and block agent_send."""
         waker = TelegramWaker(waker_registry)
         with patch("a2a_mcp_bridge.wake.urlopen", side_effect=RuntimeError("boom")):
-            # best-effort layer: never raise to caller
             assert waker.wake("vlbeau-main", sender_id="a") is False
 
-    def test_message_contains_inbox_hint(self, waker_registry: dict[str, WakeEntry]) -> None:
+    def test_message_contains_inbox_hint(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
         waker = TelegramWaker(waker_registry)
         fake_response = MagicMock()
         fake_response.__enter__.return_value = fake_response
@@ -191,16 +309,13 @@ class TestTelegramWakerWake:
             waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
 
         body = up.call_args.args[0].data.decode("utf-8")
-        # The prompt should hint at agent_inbox so the recipient knows what to do
         assert "agent_inbox" in body
 
     def test_message_names_reply_target_explicitly(
         self, waker_registry: dict[str, WakeEntry]
     ) -> None:
-        """Regression guard (v0.4.1): the wake-up text must make the reply-to
-        agent_id unambiguous so an LLM reading it cannot confuse it with a
-        Telegram bot username or chat peer.
-        """
+        """Regression guard (v0.4.1): wake-up text must name the reply-to
+        agent_id unambiguously."""
         waker = TelegramWaker(waker_registry)
         fake_response = MagicMock()
         fake_response.__enter__.return_value = fake_response
@@ -210,29 +325,21 @@ class TestTelegramWakerWake:
         with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake_response) as up:
             waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
 
-        # The HTTP POST body is urlencoded form data; decode it to recover the text
         import urllib.parse as _up
 
         encoded = up.call_args.args[0].data.decode("utf-8")
         parsed = dict(_up.parse_qsl(encoded))
         text = parsed["text"]
 
-        # Must name the sender as a copy-pasteable agent_id
         assert "vlbeau-glm51" in text
-        # Must mention both tools the recipient will use
         assert "agent_inbox" in text
         assert "agent_send" in text
-        # Must show the exact reply-to call signature
         assert 'target="vlbeau-glm51"' in text
-        # Must label the sender as the reply target so LLMs don't guess
         assert "reply-to" in text.lower()
 
     # ----- v0.4.2: forum topic routing via message_thread_id ---------------- #
 
     def test_wake_posts_message_thread_id_when_set(self) -> None:
-        """When the WakeEntry has a ``thread_id``, the POST must include
-        ``message_thread_id`` so Telegram routes to the correct forum topic.
-        """
         registry = {
             "vlbeau-main": WakeEntry(
                 bot_token="T:TOKEN",
@@ -250,15 +357,12 @@ class TestTelegramWakerWake:
             waker.wake("vlbeau-main", sender_id="vlbeau-glm51")
 
         body = up.call_args.args[0].data.decode("utf-8")
-        # Telegram field name in the API is message_thread_id
         assert "message_thread_id=5" in body
-        # chat_id still present (not replaced by thread_id)
         assert "chat_id=" in body
 
     def test_wake_omits_message_thread_id_when_unset(
         self, waker_registry: dict[str, WakeEntry]
     ) -> None:
-        """v0.4.1 behaviour preserved: no thread_id → no message_thread_id."""
         waker = TelegramWaker(waker_registry)
         fake_response = MagicMock()
         fake_response.__enter__.return_value = fake_response
@@ -270,3 +374,85 @@ class TestTelegramWakerWake:
 
         body = up.call_args.args[0].data.decode("utf-8")
         assert "message_thread_id" not in body
+
+
+# --------------------------------------------------------------------------- #
+# TelegramWaker.wake — shared-bot mode (v0.4.3+)
+# --------------------------------------------------------------------------- #
+
+
+class TestTelegramWakerSharedBot:
+    """Every wake-up is POSTed through ``shared_token`` regardless of target."""
+
+    def test_wake_uses_shared_token_not_entry_token(self) -> None:
+        """The shared token must be used even if the entry has a stale one."""
+        registry = {
+            "vlbeau-deepseek": WakeEntry(
+                bot_token="STALE:IGNORE_ME",  # should NOT be used
+                chat_id="-100111",
+                thread_id=9,
+            ),
+        }
+        waker = TelegramWaker(registry, shared_token="WAKE_BOT:TOKEN")
+        fake = MagicMock()
+        fake.__enter__.return_value = fake
+        fake.status = 200
+        with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake) as up:
+            ok = waker.wake("vlbeau-deepseek", sender_id="vlbeau-glm51")
+        assert ok is True
+        url = up.call_args.args[0].full_url
+        assert "WAKE_BOT:TOKEN" in url
+        assert "STALE:IGNORE_ME" not in url
+
+    def test_wake_routes_to_correct_topic(self) -> None:
+        """Shared bot + thread_id → POST includes message_thread_id."""
+        registry = {
+            "vlbeau-deepseek": WakeEntry(bot_token="", chat_id="-100111", thread_id=9),
+        }
+        waker = TelegramWaker(registry, shared_token="WAKE:TOK")
+        fake = MagicMock()
+        fake.__enter__.return_value = fake
+        fake.status = 200
+        with patch("a2a_mcp_bridge.wake.urlopen", return_value=fake) as up:
+            waker.wake("vlbeau-deepseek", sender_id="vlbeau-glm51")
+        body = up.call_args.args[0].data.decode("utf-8")
+        assert "message_thread_id=9" in body
+        assert "chat_id=-100111" in body
+
+    def test_uses_shared_token_property_flag(self) -> None:
+        legacy = TelegramWaker({})
+        shared = TelegramWaker({}, shared_token="T:TOK")
+        assert legacy.uses_shared_token is False
+        assert shared.uses_shared_token is True
+
+    def test_empty_entry_token_in_legacy_mode_returns_false(self) -> None:
+        """Entries with no bot_token AND no shared_token cannot be waked."""
+        registry = {
+            "vlbeau-orphan": WakeEntry(bot_token="", chat_id="-100111", thread_id=3),
+        }
+        waker = TelegramWaker(registry)  # no shared_token
+        with patch("a2a_mcp_bridge.wake.urlopen") as up:
+            assert waker.wake("vlbeau-orphan", sender_id="a") is False
+        up.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Self-wake guard (v0.4.3) — sender == target must NEVER trigger a POST
+# --------------------------------------------------------------------------- #
+
+
+class TestSelfWakeGuard:
+    def test_self_wake_is_silently_skipped_legacy(
+        self, waker_registry: dict[str, WakeEntry]
+    ) -> None:
+        waker = TelegramWaker(waker_registry)
+        with patch("a2a_mcp_bridge.wake.urlopen") as up:
+            assert waker.wake("vlbeau-main", sender_id="vlbeau-main") is False
+        up.assert_not_called()
+
+    def test_self_wake_is_silently_skipped_shared(self) -> None:
+        registry = {"vlbeau-main": WakeEntry(bot_token="", chat_id="-100111")}
+        waker = TelegramWaker(registry, shared_token="T:TOK")
+        with patch("a2a_mcp_bridge.wake.urlopen") as up:
+            assert waker.wake("vlbeau-main", sender_id="vlbeau-main") is False
+        up.assert_not_called()

--- a/tests/test_wake_integration.py
+++ b/tests/test_wake_integration.py
@@ -150,7 +150,8 @@ class TestWakerEntryShape:
         reg_path = tmp_path / "wake.json"
         reg_path.write_text(json.dumps(reg))
 
-        loaded = load_registry(str(reg_path))
-        waker = TelegramWaker(loaded)
+        shared, loaded = load_registry(str(reg_path))
+        waker = TelegramWaker(loaded, shared_token=shared)
         assert waker.has("alice")
         assert loaded["alice"] == WakeEntry(bot_token="T:TOKEN", chat_id="111")
+        assert shared is None  # legacy format → no shared token


### PR DESCRIPTION
In a Telegram supergroup, a bot does NOT receive its own messages.

v0.4.2's forum-topic routing correctly posted each wake-up into the recipient's topic — but it used the recipient's own bot token as the sender. Result: the wake-up appeared in the topic (visible to operators) but never reached the recipient's gateway (no incoming update from Telegram's perspective, since the bot ignores its own posts). Symptom observed in prod: the 6 dormant agents (deepseek/gemini/heavy/mistral/qwen36/magent) stayed dormant even though their topic had new wake-up messages.

## Fix

Post every wake-up through a **single shared bot** (typically the orchestrator, `vlbeau-main` / `@VLBeauBot`). The recipient's bot then sees an actual incoming Telegram update from a different sender, and its Hermes gateway reacts normally.

## Registry format v2

```json
{
  "wake_bot_token": "123:ABC",
  "agents": {
    "vlbeau-main":  {"chat_id": "-1001234567890", "thread_id": 5},
    "vlbeau-glm51": {"chat_id": "-1001234567890", "thread_id": 7}
  }
}
```

The top-level `wake_bot_token` is used to POST every wake-up. Each entry carries only `chat_id` and optional `thread_id` — per-agent `bot_token` is no longer needed.

The legacy v0.3 – v0.4.2 shape (one `bot_token` per entry) is still accepted for backwards compatibility, but `load_registry()` emits a migration warning the first time it parses one. Operators who still want per-agent DM wake-ups (no supergroup) can keep the legacy shape by running `wake-registry init --legacy-format`.

## Other safety additions

- **Self-wake guard**: `TelegramWaker.wake()` silently returns `False` when `agent_id == sender_id`, preventing wake-loops on the same gateway if a buggy caller ever sends a message to itself.
- **`message_thread_id` alias**: entries accept both `thread_id` (shorter) and `message_thread_id` (Telegram-native). Operators typing the Bot API name by reflex no longer get a silent drop.
- **`init` fails loudly** when the new format is requested but no wake-bot token can be resolved (missing `TELEGRAM_BOT_TOKEN` + no prior registry to reuse). Previously this would have silently produced an unusable registry.
- **`init` migrates legacy prior registries transparently** to the new format, preserving any `thread_id` overrides an operator had added by hand.

## API change

`load_registry(path)` now returns a `(shared_token, entries)` tuple instead of just `entries`. The in-tree caller (`server._load_waker`) is updated in the same commit. External callers consuming `a2a_mcp_bridge.wake.load_registry` directly must unpack the tuple.

## Testing

- **111/111 tests pass** (up from 96 in v0.4.2).
- 15 new tests: `TestLoadRegistrySharedBot`, `TestTelegramWakerSharedBot`, `TestSelfWakeGuard`, legacy-format warning regression guard, 7 new CLI tests covering all 3 code paths (new default, `--wake-bot-profile`, `--legacy-format`).
- ruff clean, mypy clean.

## Migration for existing deployments

1. Verify `~/.hermes/profiles/main/.env` has a valid `TELEGRAM_BOT_TOKEN` — that token becomes the shared wake bot.
2. Run `a2a-mcp-bridge wake-registry init` — existing `thread_id` overrides are preserved into the new format.
3. Restart the Hermes gateways so MCP bridge child processes reload the registry.

The in-prod VLBeau registry at `~/.a2a-wake-registry.json` needs this migration — will be done via `vlbeau-gateways redeploy` after merge.

## Related

- v0.4.2 (PR #8) — shipped `thread_id` field but didn't work end-to-end because of the self-wake problem documented above.
- v0.5 (next) — observability (stats CLI + structured JSON logs), not blocked by this PR.
