### PR TITLE
fix(cli): preserve chat_id across wake-registry init regenerations (v0.4.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3.1] - 2026-04-22
+
+Hotfix for `wake-registry init` silently resetting `chat_id` overrides.
+
+### Fixed
+- **`wake-registry init` now preserves `chat_id` across regenerations**, not
+  just `thread_id`. In v0.4.3 a second invocation would re-read `chat_id`
+  from every profile's `.env` and overwrite any supergroup id the operator
+  had set in the registry. When profile `.env` files carry a DM chat id
+  (typical Hermes default) but the registry was pointing at a Telegram
+  supergroup (`-100...`), this turned every wake-up into a DM silently.
+  The merge now carries `chat_id` forward just like `thread_id`.
+
+### Added
+- **`wake-registry init --reset-chat-ids`** — opt-in flag to force the old
+  v0.4.3 behaviour, re-reading `chat_id` from each profile's `.env` even
+  when the existing registry already has one. `thread_id` is still
+  preserved in this mode.
+- The CLI summary now reports how many `chat_id` and `thread_id` entries
+  were preserved (vs. pulled from `.env`) so operators get a clear signal
+  that the merge actually carried overrides forward.
+
+### Migration
+No action required. A regular `a2a-bridge wake-registry init` under v0.4.3.1
+on a v0.4.3 registry will preserve your existing `chat_id` and `thread_id`
+overrides — which is what v0.4.3 _should_ have done. If you want the old
+reset-everything behaviour on purpose, add `--reset-chat-ids`.
+
 ## [0.4.3] - 2026-04-22
 
 Shared-wake-bot format. Resolves the self-wake dead-end introduced by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.4.3"
+version = "0.4.3.1"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/cli.py
+++ b/src/a2a_mcp_bridge/cli.py
@@ -290,26 +290,33 @@ def _load_existing_registry(path: Path) -> tuple[str | None, dict[str, dict[str,
 
 
 # Keys that ``wake-registry init`` will preserve from the existing registry
-# when an entry already exists for the same agent_id. Chat_id and bot_token
-# are overwritten from the current Hermes .env source; everything else in
-# this tuple is carried forward so operators can edit freely.
-_PRESERVE_KEYS = ("thread_id",)
+# when an entry already exists for the same agent_id. ``thread_id`` must be
+# preserved because Hermes .env files do not carry it. ``chat_id`` is also
+# preserved by default because operators frequently point registries at a
+# shared Telegram supergroup (chat_id = -100...) whose id lives in the
+# registry, not in every profile's .env. Operators can force relooking-up
+# chat_id from .env by passing ``--reset-chat-ids``.
+_PRESERVE_KEYS_DEFAULT = ("chat_id", "thread_id")
+_PRESERVE_KEYS_RESET_CHAT = ("thread_id",)
 
 
 def _merge_with_existing(
     new_entry: dict[str, Any],
     existing_entry: dict[str, Any] | None,
+    *,
+    reset_chat_ids: bool = False,
 ) -> dict[str, Any]:
     """Merge a freshly-built env entry with its prior value, keeping overrides.
 
-    Any key listed in :data:`_PRESERVE_KEYS` found in the existing entry is
-    carried over, so operators can edit ``thread_id`` by hand without fearing
-    that the next ``wake-registry init`` will nuke their change.
+    By default, both ``chat_id`` and ``thread_id`` found in the existing entry
+    are carried over. Pass ``reset_chat_ids=True`` to force re-reading
+    ``chat_id`` from the profile's ``.env`` (``thread_id`` is still preserved).
     """
     if not existing_entry:
         return new_entry
     merged = dict(new_entry)
-    for key in _PRESERVE_KEYS:
+    preserve = _PRESERVE_KEYS_RESET_CHAT if reset_chat_ids else _PRESERVE_KEYS_DEFAULT
+    for key in preserve:
         if key in existing_entry:
             merged[key] = existing_entry[key]
     return merged
@@ -357,6 +364,18 @@ def wake_registry_init(
             "per-agent DM wake-up setups. Not recommended."
         ),
     ),
+    reset_chat_ids: bool = typer.Option(
+        False,
+        "--reset-chat-ids",
+        help=(
+            "Force re-reading chat_id for every agent from its profile's "
+            ".env, even when a chat_id already exists in the current "
+            "registry. By default, chat_id is preserved across regenerations "
+            "(like thread_id) so that operators pointing at a supergroup "
+            "whose id does not live in each .env do not get their registry "
+            "silently reset to DM channels."
+        ),
+    ),
 ) -> None:
     """Build the Telegram wake-up registry from existing Hermes profiles.
 
@@ -391,7 +410,9 @@ def wake_registry_init(
         entry = build_entry(_parse_env_file(root_env_path))
         if entry:
             registry_agents[ROOT_PROFILE_AGENT_ID] = _merge_with_existing(
-                entry, prior_agents.get(ROOT_PROFILE_AGENT_ID)
+                entry,
+                prior_agents.get(ROOT_PROFILE_AGENT_ID),
+                reset_chat_ids=reset_chat_ids,
             )
 
     # One entry per profile subdirectory
@@ -409,7 +430,9 @@ def wake_registry_init(
             console.print(f"[yellow]skip[/yellow] {agent_id} (invalid id)")
             continue
         registry_agents[agent_id] = _merge_with_existing(
-            entry, prior_agents.get(agent_id)
+            entry,
+            prior_agents.get(agent_id),
+            reset_chat_ids=reset_chat_ids,
         )
 
     # Resolve the shared wake-bot token (new format only).
@@ -452,9 +475,25 @@ def wake_registry_init(
         )
         return
 
-    # Report how many thread_id overrides were preserved so operators notice
-    # when a merge actually did something useful.
-    preserved = sum(1 for e in registry_agents.values() if "thread_id" in e)
+    # Report how many overrides were preserved so operators notice when
+    # a merge actually did something useful. For each agent, count the entry
+    # once per preserved key that came from the prior registry.
+    preserved_thread = sum(
+        1
+        for aid, e in registry_agents.items()
+        if "thread_id" in e
+        and prior_agents.get(aid, {}).get("thread_id") == e.get("thread_id")
+    )
+    preserved_chat = (
+        0
+        if reset_chat_ids
+        else sum(
+            1
+            for aid, e in registry_agents.items()
+            if prior_agents.get(aid, {}).get("chat_id") == e.get("chat_id")
+            and aid in prior_agents
+        )
+    )
 
     title_mode = "legacy per-agent" if legacy_format else f"shared-bot ({wake_bot_profile})"
     table = Table(
@@ -467,11 +506,21 @@ def wake_registry_init(
         tid = entry.get("thread_id")
         table.add_row(aid, str(entry["chat_id"]), "—" if tid is None else str(tid))
     console.print(table)
-    if preserved:
-        console.print(
-            f"[dim]preserved thread_id on {preserved} entr"
-            f"{'y' if preserved == 1 else 'ies'} from prior registry[/dim]"
+    notes = []
+    if preserved_chat:
+        notes.append(
+            f"preserved chat_id on {preserved_chat} entr"
+            f"{'y' if preserved_chat == 1 else 'ies'}"
         )
+    if preserved_thread:
+        notes.append(
+            f"preserved thread_id on {preserved_thread} entr"
+            f"{'y' if preserved_thread == 1 else 'ies'}"
+        )
+    if reset_chat_ids:
+        notes.append("chat_id reset requested (re-read from .env)")
+    if notes:
+        console.print(f"[dim]{' • '.join(notes)}[/dim]")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_wake_registry.py
+++ b/tests/test_cli_wake_registry.py
@@ -415,3 +415,231 @@ def test_legacy_format_emits_old_shape(tmp_path: Path) -> None:
     # Legacy shape: no top-level wake_bot_token, entries carry bot_token
     assert "wake_bot_token" not in payload
     assert payload["vlbeau-main"] == {"bot_token": "111:MAIN", "chat_id": "1000"}
+
+
+# --------------------------------------------------------------------------- #
+# v0.4.3.1: chat_id preservation across regenerations
+# --------------------------------------------------------------------------- #
+
+
+def test_wake_registry_init_preserves_chat_id_across_regenerations(
+    tmp_path: Path,
+) -> None:
+    """A chat_id overridden to a supergroup id must survive re-init.
+
+    Regression for v0.4.3 where a second ``wake-registry init`` would reset
+    every chat_id back to whatever lived in the profile's ``.env``, silently
+    breaking operators who had pointed the registry at a Telegram supergroup
+    (chat_id = -100...) whose id is not in each profile's .env.
+    """
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    (profiles / "glm51").mkdir()
+    # .env carries a DM chat_id, but operator has overridden both agents
+    # to point at a supergroup (-100...) in the registry.
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1395012867",  # DM id
+    )
+    _write_env(
+        profiles / "glm51" / ".env",
+        TELEGRAM_BOT_TOKEN="222:GLM",
+        TELEGRAM_HOME_CHANNEL="1395012867",  # DM id
+    )
+
+    out = tmp_path / "wake.json"
+    # Seed: registry points at supergroup with thread_ids
+    out.write_text(
+        json.dumps(
+            {
+                "wake_bot_token": "111:MAIN",
+                "agents": {
+                    "vlbeau-main": {
+                        "chat_id": "-1003997069076",
+                        "thread_id": 5,
+                    },
+                    "vlbeau-glm51": {
+                        "chat_id": "-1003997069076",
+                        "thread_id": 7,
+                    },
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+
+    # Both agents: chat_id preserved (supergroup), thread_id preserved, no DM leak.
+    assert payload["agents"]["vlbeau-main"]["chat_id"] == "-1003997069076"
+    assert payload["agents"]["vlbeau-main"]["thread_id"] == 5
+    assert payload["agents"]["vlbeau-glm51"]["chat_id"] == "-1003997069076"
+    assert payload["agents"]["vlbeau-glm51"]["thread_id"] == 7
+
+
+def test_wake_registry_init_reset_chat_ids_reads_from_env(tmp_path: Path) -> None:
+    """``--reset-chat-ids`` forces re-reading chat_id from each profile's .env.
+
+    thread_id overrides must still be preserved — only chat_id is re-read.
+    """
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1395012867",  # DM id in .env
+    )
+
+    out = tmp_path / "wake.json"
+    out.write_text(
+        json.dumps(
+            {
+                "wake_bot_token": "111:MAIN",
+                "agents": {
+                    "vlbeau-main": {
+                        "chat_id": "-1003997069076",  # supergroup override
+                        "thread_id": 5,
+                    },
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+            "--reset-chat-ids",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+
+    # chat_id reset to .env value, thread_id still preserved
+    assert payload["agents"]["vlbeau-main"]["chat_id"] == "1395012867"
+    assert payload["agents"]["vlbeau-main"]["thread_id"] == 5
+
+
+def test_wake_registry_init_chat_id_uses_env_for_new_agents(tmp_path: Path) -> None:
+    """An agent absent from the prior registry gets chat_id from its .env.
+
+    Preservation only triggers when the agent already existed — brand-new
+    profiles fall through to the regular .env-sourced behaviour.
+    """
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    (profiles / "newcomer").mkdir()
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1395012867",
+    )
+    _write_env(
+        profiles / "newcomer" / ".env",
+        TELEGRAM_BOT_TOKEN="999:NEW",
+        TELEGRAM_HOME_CHANNEL="9999",
+    )
+
+    out = tmp_path / "wake.json"
+    # Prior registry has main at supergroup, but no entry for newcomer.
+    out.write_text(
+        json.dumps(
+            {
+                "wake_bot_token": "111:MAIN",
+                "agents": {
+                    "vlbeau-main": {"chat_id": "-1003997069076", "thread_id": 5},
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(out.read_text())
+
+    # Existing agent preserved, newcomer gets .env chat_id.
+    assert payload["agents"]["vlbeau-main"]["chat_id"] == "-1003997069076"
+    assert payload["agents"]["vlbeau-newcomer"]["chat_id"] == "9999"
+
+
+def test_wake_registry_init_reports_preservation_in_stdout(tmp_path: Path) -> None:
+    """The CLI must mention chat_id preservation in its summary output.
+
+    Operators need a signal that the merge actually carried the override
+    forward, otherwise a typo in the prior registry silently propagates.
+    """
+    hermes = tmp_path / ".hermes"
+    profiles = hermes / "profiles"
+    (profiles / "main").mkdir(parents=True)
+    _write_env(
+        profiles / "main" / ".env",
+        TELEGRAM_BOT_TOKEN="111:MAIN",
+        TELEGRAM_HOME_CHANNEL="1000",
+    )
+
+    out = tmp_path / "wake.json"
+    out.write_text(
+        json.dumps(
+            {
+                "wake_bot_token": "111:MAIN",
+                "agents": {
+                    "vlbeau-main": {"chat_id": "-1003997069076", "thread_id": 5},
+                },
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "wake-registry",
+            "init",
+            "--hermes-profiles",
+            str(profiles),
+            "--hermes-root",
+            str(hermes),
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    # stdout should mention chat_id preservation
+    assert "chat_id" in result.stdout
+    # And thread_id preservation
+    assert "thread_id" in result.stdout


### PR DESCRIPTION
## Context

Regression reported by `vlbeau-opus` after the v0.4.3 rollout: a second `wake-registry init` silently reset every agent's `chat_id` back to the DM default from each profile's `.env`, even when the registry had been pointing at a Telegram supergroup (chat_id = `-100...`). Thread_ids were preserved, chat_ids were not — an asymmetric merge that turned every wake-up into a DM silently.

## Root cause

```python
# v0.4.3
_PRESERVE_KEYS = ("thread_id",)   # chat_id missing
```

## Fix

- Treat `chat_id` exactly like `thread_id` in `_merge_with_existing`: preserve from prior registry when present, fall through to `.env` only for brand-new agents.
- Add `--reset-chat-ids` opt-in flag to force the old v0.4.3 behaviour for operators who _want_ to pull chat_id back from `.env`. `thread_id` overrides are still preserved in that mode.
- CLI summary now separately reports `chat_id` and `thread_id` preservation counts — operators get a visible signal that the merge did something.

## Tests

4 new cases (regression + opt-in + newcomers + stdout reporting). **115/115 pass** (+4 vs v0.4.3), ruff clean, mypy clean.

## Migration

No action required. v0.4.3.1 now preserves existing `chat_id` and `thread_id` overrides — which is what v0.4.3 _should_ have done. Pass `--reset-chat-ids` to opt into the old behaviour.