### PR TITLE
v0.5: bridge primitives (session_id + inbox_peek + migration + structured logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ restarts and to correlate log lines across concurrent agent sessions.
 - **`agent_send` session propagation** — when the caller supplies
   `metadata={"session_id": "..."}`, the value is stored in
   `messages.sender_session_id` and surfaced to the recipient's inbox
-  payload. Non-string or oversize values are ignored (no error).
+  payload. Non-string or oversize values are rejected with error codes
+  `SESSION_ID_INVALID` / `SESSION_ID_TOO_LARGE` (≤ 128 chars).
 - **`src/a2a_mcp_bridge/logging_ext.py`** — structured logging helper.
   Minimum schema: `{ts, level, event, agent_id}`; optional extras:
   `session_id, message_id, target, duration_ms, body_hash, error_code`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ restarts and to correlate log lines across concurrent agent sessions.
   or when lagging behind the bus, but external tooling can also use it
   to inspect an agent's history without consuming pending messages.
 - **`messages.sender_session_id` column** — optional opaque correlator
-  (≤ 128 chars, nullable) stored alongside every inbound message. Payload
+  (≤ 128 bytes UTF-8, nullable) stored alongside every inbound message. Payload
   shapes of `agent_inbox`, `agent_inbox_peek`, and `agent_subscribe` now
   include `"sender_session_id"` for every message (always present, `null`
   when absent). Pre-v0.5 callers that ignore unknown keys are unaffected.
@@ -35,7 +35,7 @@ restarts and to correlate log lines across concurrent agent sessions.
   `metadata={"session_id": "..."}`, the value is stored in
   `messages.sender_session_id` and surfaced to the recipient's inbox
   payload. Non-string or oversize values are rejected with error codes
-  `SESSION_ID_INVALID` / `SESSION_ID_TOO_LARGE` (≤ 128 chars).
+  `SESSION_ID_INVALID` / `SESSION_ID_TOO_LARGE` (≤ 128 bytes UTF-8).
 - **`src/a2a_mcp_bridge/logging_ext.py`** — structured logging helper.
   Minimum schema: `{ts, level, event, agent_id}`; optional extras:
   `session_id, message_id, target, duration_ms, body_hash, error_code`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-23
+
+**Theme** — bridge-side primitives for multi-session concurrency (ADR-001
+Option A′: leader-at-gateway). The bridge now ships the building blocks
+the Hermes gateway needs to recover its inbox cache across process
+restarts and to correlate log lines across concurrent agent sessions.
+
+### Added
+- **`agent_inbox_peek(since_ts?, limit=50)`** — read-only inbox view that
+  never mutates `read_at`. Returns the same message payload shape as
+  `agent_inbox`, including already-read messages with their `read_at`
+  populated. When `since_ts` is supplied, messages are returned ASC by
+  `created_at` (replay order); otherwise newest-first. Primary consumer
+  is the Hermes gateway reconstructing its local cache after a restart
+  or when lagging behind the bus, but external tooling can also use it
+  to inspect an agent's history without consuming pending messages.
+- **`messages.sender_session_id` column** — optional opaque correlator
+  (≤ 128 chars, nullable) stored alongside every inbound message. Payload
+  shapes of `agent_inbox`, `agent_inbox_peek`, and `agent_subscribe` now
+  include `"sender_session_id"` for every message (always present, `null`
+  when absent). Pre-v0.5 callers that ignore unknown keys are unaffected.
+- **`session_id` session tagging on read tools** — `agent_inbox`,
+  `agent_inbox_peek`, `agent_list`, and `agent_subscribe` accept an
+  optional `session_id: str | None = None` kwarg. The bridge does not
+  interpret the value beyond tagging its log events with it, enabling
+  end-to-end log correlation when multiple gateway sessions operate
+  concurrently on the same bridge (ADR-001 §4 #3).
+- **`agent_send` session propagation** — when the caller supplies
+  `metadata={"session_id": "..."}`, the value is stored in
+  `messages.sender_session_id` and surfaced to the recipient's inbox
+  payload. Non-string or oversize values are ignored (no error).
+- **`src/a2a_mcp_bridge/logging_ext.py`** — structured logging helper.
+  Minimum schema: `{ts, level, event, agent_id}`; optional extras:
+  `session_id, message_id, target, duration_ms, body_hash, error_code`.
+  Two output formats, toggled at import time by `A2A_LOG_JSON`:
+  - `A2A_LOG_JSON=1` → one JSON object per line (log-shipper friendly).
+  - unset / anything else → classic plain-text matching the pre-v0.5
+    format (no existing tailer breaks).
+  Message bodies are NEVER logged verbatim; only a 16-hex
+  `blake2b(digest_size=8)` `body_hash` is emitted — traceable, non-PII.
+
+### Changed
+- Every MCP tool handler now measures its own wall time and emits one
+  INFO log record at completion (or WARN on the `agent_send` error
+  path), carrying `event`, `agent_id`, `duration_ms`, and when relevant
+  `session_id`, `target`, `message_id`, `body_hash`, `error_code`.
+- **Schema migration is idempotent.** Existing DBs add the new column
+  via `ALTER TABLE ... ADD COLUMN sender_session_id TEXT` on first open;
+  re-opening an already-migrated DB is a no-op. Downgrading to v0.4.x
+  is safe — the column is simply unused.
+
+### Notes / caveats
+- **FastMCP parameter convention**: the `session_id` parameter on read
+  tools is spelled without an underscore prefix. FastMCP's signature
+  validator rejects any tool parameter starting with `_`
+  (`InvalidSignature: Parameter _session_id ... cannot start with '_'`).
+  Earlier WIP used `_session_id` as a "plumbing hint" — that convention
+  is incompatible with the MCP boundary.
+- **ADR-002 (`docs/adr/ADR-002-wake-intent-coupling.md`)** documents a
+  related post-mortem (wake-intent coupling) observed during v0.5
+  development on the `docs/adr-002-wake-intent` branch. That branch is
+  being landed separately; it has no code dependency on v0.5.
+
+### Tests
+- 30 new tests across `tests/test_migrations.py`, `tests/test_inbox_peek.py`,
+  `tests/test_session_id.py`, `tests/test_logging.py`.
+- Full suite: **142 passed**, ruff clean, mypy clean on `src/`.
+
 ## [0.4.4] - 2026-04-22
 
 **Major** — wake-up transport migrates from Telegram to local HTTP webhooks.

--- a/README.md
+++ b/README.md
@@ -535,6 +535,53 @@ a2a-mcp-bridge register --all --hermes-profiles ~/.hermes/profiles
 | `A2A_DB_PATH` | `./a2a-bus.sqlite` | SQLite file (shared by all agents on the bus). |
 | `A2A_SIGNAL_DIR` | `/tmp/a2a-signals` | Directory used by `agent_subscribe` for real-time wake-ups. |
 | `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | JSON wake registry. v0.4.4+ shape: `{"wake_webhook_secret": "...", "agents": {<id>: {"wake_webhook_url": "..."}}}`. Legacy Telegram-based registries (`wake_bot_token` or per-agent `bot_token`) are detected, logged with a migration warning, and treated as "wake-up disabled" until regenerated. Missing/invalid file → feature silently disabled. |
+| `A2A_LOG_JSON` | *unset* | If set to `1` / `true` / `yes`, every tool call emits a one-object-per-line JSON log record (schema: `ts`, `level`, `event`, `agent_id`, + `session_id`/`message_id`/`target`/`duration_ms`/`body_hash`/`error_code` when applicable). Unset keeps the pre-v0.5 plain-text format. Evaluated at import time — change requires a server restart. |
+| `A2A_LOG_LEVEL` | `INFO` | Log verbosity. |
+
+## Multi-session concurrency (ADR-001) & MCP docstring visibility
+
+Since v0.5, every MCP tool's docstring opens with a short "Note
+(multi-session)" paragraph that clarifies a critical property of the bus:
+**`agent_id` identifies a profile, not a conversation**. A single profile
+can be served concurrently by multiple Hermes sessions (Telegram, webhook
+wake-up, cron, CLI) behind a local gateway cache — see
+[`docs/adr/ADR-001-multi-session-concurrency.md`](docs/adr/ADR-001-multi-session-concurrency.md)
+for the full model and the v0.5 bridge-side primitives that support it:
+
+1. `agent_inbox_peek(since_ts, limit)` — read-only inbox view, no
+   mark-as-read. Safe to call concurrently from any session. Used by the
+   gateway for cache recovery and by tooling that wants a global view.
+2. Optional `metadata.session_id` on `agent_send` — a reserved key (≤ 128
+   chars) that gets hoisted into a dedicated column and surfaced at the top
+   level of the `agent_inbox` / `agent_inbox_peek` payload, so recipients
+   can correlate a reply with the exact sender session. Validation errors:
+   `SESSION_ID_INVALID`, `SESSION_ID_TOO_LARGE`.
+3. Structured logging — every tool call emits one record with a minimum
+   schema (`ts`, `level`, `event`, `agent_id`) plus optional `session_id`,
+   `message_id`, `target`, `duration_ms`, `body_hash`, `error_code`. Toggle
+   JSON output via `A2A_LOG_JSON=1`. Bodies and caller metadata are never
+   logged verbatim — only a 16-hex `blake2b(digest_size=8)` fingerprint.
+4. Optional `session_id` parameter on every read tool (`agent_inbox`,
+   `agent_inbox_peek`, `agent_list`, `agent_subscribe`) for log tagging
+   from non-`agent_send` call sites.
+
+### FastMCP docstring visibility caveat
+
+FastMCP serves each MCP tool's first docstring line as its tool
+description, but **ignores everything after the first blank line** when
+streaming tool metadata to some MCP clients (observed on Hermes'
+stdio client, 2026-04-22, with `fastmcp` 2.x). For that reason the full
+"Note (multi-session)" paragraph is also present here in the README as a
+single source of truth, and individual tool docstrings point back to the
+ADR rather than duplicating the full design rationale.
+
+**Also note**: FastMCP rejects any MCP tool parameter whose name starts
+with an underscore (`InvalidSignature: Parameter _foo cannot start with '_'`).
+The plumbing-style convention "prefix private-ish metadata with `_`" that
+works in ordinary Python code is therefore unusable at the MCP boundary.
+The public `session_id` parameter on the v0.5 read tools carries no
+underscore for that reason, even though its role is conceptually
+out-of-band from business input.
 
 ## CLI reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.4.4"
+version = "0.5.0"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.5.0"
+version = "0.4.4"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/logging_ext.py
+++ b/src/a2a_mcp_bridge/logging_ext.py
@@ -1,0 +1,112 @@
+"""Session-tagged logging helpers for MCP tool handlers (ADR-001 §4 #3, v0.5).
+
+Two output formats are supported and selected at import time via the
+``A2A_LOG_JSON`` environment variable:
+
+* ``A2A_LOG_JSON=1`` → one JSON object per line, suitable for log shippers.
+* anything else (including unset) → classic plain-text lines that match the
+  pre-v0.5 output so existing tailers don't break.
+
+Log records always carry a minimum schema:
+
+* ``ts``          — ISO-8601 UTC timestamp
+* ``level``       — logging level name (INFO / WARNING / ERROR)
+* ``event``       — short snake_case identifier (e.g. ``tool.agent_send``)
+* ``agent_id``    — the bridge's own identity (caller of the MCP tool)
+
+Additional optional fields when relevant:
+
+* ``session_id``  — from the caller-provided ``session_id`` metadata on
+  ``agent_send`` or the ``session_id`` parameter on read tools
+* ``message_id``  — for ``agent_send`` responses
+* ``target``      — recipient of ``agent_send``
+* ``duration_ms`` — wall time of the tool call in milliseconds
+* ``error_code``  — on error paths
+* ``body_hash``   — blake2b(digest_size=8) of the message body, used as a
+  traceable-but-non-PII fingerprint in logs. NEVER the raw body.
+
+The plain-text format renders the key/value pairs after the logger's own
+prefix, e.g.::
+
+    2026-04-23 09:31:12 INFO a2a_mcp_bridge.tools: agent_send [session=abc123] target=vlbeau-main message_id=ff... duration_ms=8.4
+
+Design decisions:
+
+* We do not introduce a logging dependency (no ``structlog`` / ``orjson``) —
+  ``json.dumps`` is enough and the record count is small (one line per tool
+  call).
+* The JSON flag is read at import time. Runtime changes would require a
+  server restart, but so does any other ``A2A_*`` env var, so the asymmetry
+  is acceptable.
+* PII: bodies and caller-supplied metadata (other than ``session_id``,
+  which is a routing id) are never emitted verbatim. Only ``body_hash``
+  goes into logs, computed with ``blake2b(digest_size=8)``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+A2A_LOG_JSON: bool = os.environ.get("A2A_LOG_JSON", "").strip() in {"1", "true", "yes"}
+
+
+def hash_body(body: str | bytes | None) -> str | None:
+    """Short, collision-resistant digest of a message body for logs.
+
+    Returns ``None`` for a missing body. Uses :func:`hashlib.blake2b` with
+    ``digest_size=8`` (16-char hex output), per Opus' 2026-04-22 guidance:
+    enough to trace a body across log lines, not enough to leak contents.
+    """
+    if body is None:
+        return None
+    if isinstance(body, str):
+        body = body.encode("utf-8", errors="replace")
+    return hashlib.blake2b(body, digest_size=8).hexdigest()
+
+
+def log_event(
+    logger: logging.Logger,
+    *,
+    event: str,
+    agent_id: str,
+    level: int = logging.INFO,
+    session_id: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit a structured event through ``logger``.
+
+    Only includes non-``None`` optional fields in the record so plain-text
+    lines stay compact. In JSON mode the full record (with the minimum
+    schema plus the provided fields) is emitted as one line.
+    """
+    record: dict[str, Any] = {
+        "ts": datetime.now(UTC).isoformat(),
+        "level": logging.getLevelName(level),
+        "event": event,
+        "agent_id": agent_id,
+    }
+    if session_id is not None:
+        record["session_id"] = session_id
+    for k, v in fields.items():
+        if v is None:
+            continue
+        record[k] = v
+
+    if A2A_LOG_JSON:
+        logger.log(level, json.dumps(record, separators=(",", ":")))
+        return
+
+    # Plain-text format: "event [session=<id>] k=v k=v ..."
+    parts: list[str] = [event]
+    if session_id is not None:
+        parts.append(f"[session={session_id}]")
+    for k, v in fields.items():
+        if v is None:
+            continue
+        parts.append(f"{k}={v}")
+    logger.log(level, " ".join(parts))

--- a/src/a2a_mcp_bridge/models.py
+++ b/src/a2a_mcp_bridge/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 AGENT_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 MAX_BODY_BYTES: int = 64 * 1024
 MAX_METADATA_BYTES: int = 4 * 1024
+MAX_SESSION_ID_LEN: int = 128
 
 
 class AgentId:
@@ -35,6 +36,7 @@ class Message(BaseModel):
     metadata: dict[str, Any] | None = None
     created_at: datetime
     read_at: datetime | None = None
+    sender_session_id: str | None = None
 
     @field_validator("sender_id", "recipient_id")
     @classmethod

--- a/src/a2a_mcp_bridge/models.py
+++ b/src/a2a_mcp_bridge/models.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 AGENT_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 MAX_BODY_BYTES: int = 64 * 1024
 MAX_METADATA_BYTES: int = 4 * 1024
-MAX_SESSION_ID_LEN: int = 128
+MAX_SESSION_ID_BYTES: int = 128
 
 
 class AgentId:

--- a/src/a2a_mcp_bridge/schema.sql
+++ b/src/a2a_mcp_bridge/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS messages (
     metadata TEXT,
     created_at TEXT NOT NULL,
     read_at TEXT,
+    sender_session_id TEXT,
     FOREIGN KEY (sender_id) REFERENCES agents(id),
     FOREIGN KEY (recipient_id) REFERENCES agents(id)
 );

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -187,7 +187,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             target: recipient agent_id (lowercase, matches ^[a-z0-9][a-z0-9_-]{0,63}$).
             message: UTF-8 text body, max 65536 bytes.
             metadata: optional JSON-serialisable dict, max 4096 bytes serialised.
-                A reserved key ``session_id`` (string, ≤ 128 chars) is
+                A reserved key ``session_id`` (string, ≤ 128 bytes UTF-8) is
                 hoisted into a dedicated column and surfaced in the inbox
                 payload — see ADR-001 §4 #2.
 

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -20,6 +20,7 @@ from .signals import SignalDir
 from .store import Store
 from .tools import (
     tool_agent_inbox,
+    tool_agent_inbox_peek,
     tool_agent_list,
     tool_agent_send,
     tool_agent_subscribe,
@@ -198,6 +199,35 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         When unread_only=True (default), returned messages are atomically marked read.
         """
         return tool_agent_inbox(store, agent_id, limit=limit, unread_only=unread_only)
+
+    @mcp.tool()
+    def agent_inbox_peek(
+        since_ts: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Read-only view of the caller's inbox — no mark-as-read.
+
+        Unlike ``agent_inbox``, this tool never mutates ``read_at``. Use it
+        when you want to inspect what's waiting (or what has been delivered)
+        without consuming it — e.g. a gateway reconstructing its local cache
+        after a restart, or tooling that wants a global view.
+
+        Args:
+            since_ts: ISO-8601 UTC timestamp. When provided, only messages
+                with ``created_at >= since_ts`` are returned, sorted ASC by
+                arrival time (replay order). When omitted, returns the
+                ``limit`` most recent messages sorted newest-first.
+            limit: max number of messages to return (clamped to [1, 200]).
+
+        Returns:
+            ``{"messages": [...]}`` with the same payload shape as
+            ``agent_inbox``. Already-read messages are included with their
+            ``read_at`` populated.
+
+        See ADR-001 §4 for the concurrency rationale (bridge-side primitive
+        introduced in v0.5).
+        """
+        return tool_agent_inbox_peek(store, agent_id, since_ts=since_ts, limit=limit)
 
     @mcp.tool()
     def agent_list(active_within_days: int = 7) -> dict[str, Any]:

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -193,17 +193,37 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         return tool_agent_send(store, agent_id, target, message, metadata, signal_dir, waker)
 
     @mcp.tool()
-    def agent_inbox(limit: int = 10, unread_only: bool = True) -> dict[str, Any]:
+    def agent_inbox(
+        limit: int = 10,
+        unread_only: bool = True,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
         """Read messages addressed to the calling agent.
 
         When unread_only=True (default), returned messages are atomically marked read.
+
+        Args:
+            limit: max messages to return.
+            unread_only: if True (default), atomically mark the returned
+                messages as read.
+            session_id: optional opaque session correlator used by the
+                caller (e.g. the Hermes gateway) to tag its own log lines.
+                Plumbing metadata — not interpreted beyond log tagging.
+                See ADR-001 §4 #3.
         """
-        return tool_agent_inbox(store, agent_id, limit=limit, unread_only=unread_only)
+        return tool_agent_inbox(
+            store,
+            agent_id,
+            limit=limit,
+            unread_only=unread_only,
+            session_id=session_id,
+        )
 
     @mcp.tool()
     def agent_inbox_peek(
         since_ts: str | None = None,
         limit: int = 50,
+        session_id: str | None = None,
     ) -> dict[str, Any]:
         """Read-only view of the caller's inbox — no mark-as-read.
 
@@ -218,6 +238,8 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
                 arrival time (replay order). When omitted, returns the
                 ``limit`` most recent messages sorted newest-first.
             limit: max number of messages to return (clamped to [1, 200]).
+            session_id: optional opaque session correlator for log tagging
+                (ADR-001 §4 #3).
 
         Returns:
             ``{"messages": [...]}`` with the same payload shape as
@@ -227,17 +249,39 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         See ADR-001 §4 for the concurrency rationale (bridge-side primitive
         introduced in v0.5).
         """
-        return tool_agent_inbox_peek(store, agent_id, since_ts=since_ts, limit=limit)
+        return tool_agent_inbox_peek(
+            store,
+            agent_id,
+            since_ts=since_ts,
+            limit=limit,
+            session_id=session_id,
+        )
 
     @mcp.tool()
-    def agent_list(active_within_days: int = 7) -> dict[str, Any]:
-        """List agents seen on the bus in the given window (default 7 days)."""
-        return tool_agent_list(store, agent_id, active_within_days=active_within_days)
+    def agent_list(
+        active_within_days: int = 7,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """List agents seen on the bus in the given window (default 7 days).
+
+        Args:
+            active_within_days: only return agents whose ``last_seen_at``
+                is within this many days of now.
+            session_id: optional opaque session correlator for log tagging
+                (ADR-001 §4 #3).
+        """
+        return tool_agent_list(
+            store,
+            agent_id,
+            active_within_days=active_within_days,
+            session_id=session_id,
+        )
 
     @mcp.tool()
     def agent_subscribe(
         timeout_seconds: float = 30.0,
         limit: int = 10,
+        session_id: str | None = None,
     ) -> dict[str, Any]:
         """Long-poll for new messages (v0.2 real-time delivery).
 
@@ -245,6 +289,12 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         for a new message to arrive for the calling agent. Returns immediately
         if messages are already pending. Payload shape matches ``agent_inbox``
         plus a ``timed_out`` boolean.
+
+        Args:
+            timeout_seconds: max seconds to block (capped at 55 s).
+            limit: max messages to return when the wait resolves.
+            session_id: optional opaque session correlator for log tagging
+                (ADR-001 §4 #3).
 
         Usage pattern for a continuously-listening agent::
 
@@ -259,6 +309,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             signal_dir=signal_dir,
             timeout_seconds=timeout_seconds,
             limit=limit,
+            session_id=session_id,
         )
 
     @mcp.tool()

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -176,19 +176,32 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     ) -> dict[str, Any]:
         """Send a message to another agent on the bus.
 
+        Note (multi-session): ``target`` identifies a **profile**, not a
+        conversation. A profile may be served concurrently by multiple
+        Hermes sessions behind a local gateway cache — see
+        ``docs/adr/ADR-001-multi-session-concurrency.md``. If you need to
+        correlate a reply with the exact sender session, pass
+        ``metadata={"session_id": "<id>"}``.
+
         Args:
             target: recipient agent_id (lowercase, matches ^[a-z0-9][a-z0-9_-]{0,63}$).
             message: UTF-8 text body, max 65536 bytes.
             metadata: optional JSON-serialisable dict, max 4096 bytes serialised.
+                A reserved key ``session_id`` (string, ≤ 128 chars) is
+                hoisted into a dedicated column and surfaced in the inbox
+                payload — see ADR-001 §4 #2.
 
         Returns:
             {"message_id", "sent_at", "recipient"} on success, or {"error": {"code", "message"}}.
+            Validation errors on the reserved session_id key:
+            ``SESSION_ID_INVALID`` (not a string) or ``SESSION_ID_TOO_LARGE``.
 
         Side effect (v0.2): writes a signal file to `A2A_SIGNAL_DIR` so that any
         agent long-polling via `agent_subscribe` wakes up immediately.
 
-        Side effect (v0.3): if `A2A_WAKE_REGISTRY` points at a valid registry
-        and the recipient is listed, fires a Telegram prompt to their bot.
+        Side effect (v0.4.4+): if `A2A_WAKE_REGISTRY` points at a valid v0.4.4
+        webhook registry, fires an HMAC-signed wake-up POST to the recipient's
+        local gateway endpoint.
         """
         return tool_agent_send(store, agent_id, target, message, metadata, signal_dir, waker)
 
@@ -199,6 +212,14 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         session_id: str | None = None,
     ) -> dict[str, Any]:
         """Read messages addressed to the calling agent.
+
+        Note (multi-session): the caller's identity (``A2A_AGENT_ID``)
+        identifies a **profile**. When ``unread_only=True`` the read is
+        atomic mark-as-read — the message then becomes invisible to any
+        sibling session of the same profile. In the v0.5 leader-at-gateway
+        model this tool is expected to be called by the gateway only; other
+        sessions should read their cache or use :func:`agent_inbox_peek`.
+        See ``docs/adr/ADR-001-multi-session-concurrency.md``.
 
         When unread_only=True (default), returned messages are atomically marked read.
 
@@ -226,6 +247,13 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         session_id: str | None = None,
     ) -> dict[str, Any]:
         """Read-only view of the caller's inbox — no mark-as-read.
+
+        Note (multi-session): the caller's identity identifies a **profile**
+        (see ``docs/adr/ADR-001-multi-session-concurrency.md``). Because
+        this tool never mutates ``read_at``, it is safe to call from any
+        session of a profile concurrently — there is no consumption race
+        with siblings. This is specifically what makes it suitable for the
+        gateway's cache recovery path.
 
         Unlike ``agent_inbox``, this tool never mutates ``read_at``. Use it
         when you want to inspect what's waiting (or what has been delivered)
@@ -264,6 +292,12 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     ) -> dict[str, Any]:
         """List agents seen on the bus in the given window (default 7 days).
 
+        Note (multi-session): each row describes a **profile** identity,
+        not a live session. Liveness (a session actually running behind
+        that profile) is not carried here — use ``agent_ping`` or send an
+        actual message to confirm. See
+        ``docs/adr/ADR-001-multi-session-concurrency.md``.
+
         Args:
             active_within_days: only return agents whose ``last_seen_at``
                 is within this many days of now.
@@ -284,6 +318,13 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         session_id: str | None = None,
     ) -> dict[str, Any]:
         """Long-poll for new messages (v0.2 real-time delivery).
+
+        Note (multi-session): the inbox consumption performed when the
+        long-poll resolves is the same atomic mark-as-read as
+        ``agent_inbox``. In the v0.5 leader-at-gateway model this should
+        be called by the gateway only; sessions that want to react to
+        sibling-cached deltas should use a profile-local cache. See
+        ``docs/adr/ADR-001-multi-session-concurrency.md``.
 
         Blocks up to ``timeout_seconds`` (capped at 55 s by the server) waiting
         for a new message to arrive for the calling agent. Returns immediately

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -26,6 +26,53 @@ class Store:
 
     def init_schema(self) -> None:
         self._conn.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
+        self._migrate_schema()
+
+    def _migrate_schema(self) -> None:
+        """Apply idempotent schema migrations to pre-existing databases.
+
+        Runs after :meth:`init_schema` so fresh DBs (which already include the
+        current columns via ``CREATE TABLE IF NOT EXISTS``) skip the ALTER
+        branches naturally. For pre-v0.5 DBs on disk we need to add columns
+        introduced later without dropping data.
+
+        Each migration step:
+          * wraps its work in ``BEGIN IMMEDIATE`` / ``COMMIT`` so a concurrent
+            writer (e.g. another Hermes profile spinning up) cannot interleave
+            between the ``PRAGMA table_info`` probe and the ``ALTER TABLE``;
+          * checks via ``PRAGMA table_info`` before attempting ``ALTER TABLE``,
+            because SQLite has no ``ADD COLUMN IF NOT EXISTS`` and a second
+            run would otherwise raise ``OperationalError``.
+
+        The migration table of contents (keep in sync with CHANGELOG):
+
+        * v0.5 — ``messages.sender_session_id TEXT NULL`` (A2A session
+          correlation, see ADR-001).
+        """
+        # v0.5 — messages.sender_session_id
+        existing_cols = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "sender_session_id" not in existing_cols:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Re-check inside the transaction in case a concurrent writer
+                # raced us between the probe above and here.
+                cols = {
+                    row["name"]
+                    for row in self._conn.execute(
+                        "PRAGMA table_info(messages)"
+                    ).fetchall()
+                }
+                if "sender_session_id" not in cols:
+                    self._conn.execute(
+                        "ALTER TABLE messages ADD COLUMN sender_session_id TEXT"
+                    )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
 
     def close(self) -> None:
         self._conn.close()

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -12,7 +12,7 @@ from typing import Any
 from .models import (
     MAX_BODY_BYTES,
     MAX_METADATA_BYTES,
-    MAX_SESSION_ID_LEN,
+    MAX_SESSION_ID_BYTES,
     AgentRecord,
     Message,
     SendResult,
@@ -147,9 +147,13 @@ class Store:
                     raise ValueError(
                         "SESSION_ID_INVALID: session_id must be a string"
                     )
-                if len(raw) > MAX_SESSION_ID_LEN:
+                # Enforce the limit in BYTES (UTF-8) to stay consistent with
+                # MAX_BODY_BYTES / MAX_METADATA_BYTES. Using len() in chars
+                # would silently let a 128-emoji session_id balloon to
+                # ~512 bytes in the DB — see GLM review nit #1 on PR #12.
+                if len(raw.encode("utf-8")) > MAX_SESSION_ID_BYTES:
                     raise ValueError(
-                        f"SESSION_ID_TOO_LARGE: session_id exceeds {MAX_SESSION_ID_LEN} chars"
+                        f"SESSION_ID_TOO_LARGE: session_id exceeds {MAX_SESSION_ID_BYTES} bytes"
                     )
                 session_id = raw
 

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -212,3 +212,70 @@ class Store:
             )
             for r in rows
         ]
+
+    def peek_inbox(
+        self,
+        agent_id: str,
+        since_ts: str | None = None,
+        limit: int = 50,
+    ) -> list[Message]:
+        """Read-only view of the caller's inbox.
+
+        Returns messages addressed to ``agent_id`` without any mark-as-read
+        side-effect. The tuple ``(read_at, read status)`` of every row is left
+        untouched — this is the crucial property that distinguishes
+        :meth:`peek_inbox` from :meth:`read_inbox`.
+
+        Semantics:
+          * ``since_ts`` is an ISO-8601 UTC timestamp string. When provided,
+            only messages with ``created_at >= since_ts`` are returned, sorted
+            **ASC** by ``created_at`` — the replay-in-order use case (gateway
+            cache recovery).
+          * When ``since_ts`` is ``None``, returns the ``limit`` most recent
+            messages sorted by ``created_at DESC``. This gives the "show me
+            my latest inbox without consuming it" use case without forcing
+            the caller to derive a timestamp.
+          * Already-read messages ARE included, with their ``read_at``
+            populated so the caller can tell who consumed them and when.
+
+        The limit is clamped to ``[1, 200]`` to protect the caller from
+        accidentally loading the entire history into a single payload.
+
+        See ADR-001 §4 (bridge-side primitive #1) for the rationale.
+        """
+        limit = max(1, min(limit, 200))
+        if since_ts is None:
+            rows = self._conn.execute(
+                """
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                FROM messages
+                WHERE recipient_id = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (agent_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                FROM messages
+                WHERE recipient_id = ? AND created_at >= ?
+                ORDER BY created_at ASC
+                LIMIT ?
+                """,
+                (agent_id, since_ts, limit),
+            ).fetchall()
+
+        return [
+            Message(
+                id=r["id"],
+                sender_id=r["sender_id"],
+                recipient_id=r["recipient_id"],
+                body=r["body"],
+                metadata=json.loads(r["metadata"]) if r["metadata"] else None,
+                created_at=datetime.fromisoformat(r["created_at"]),
+                read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
+            )
+            for r in rows
+        ]

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -9,7 +9,14 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from .models import MAX_BODY_BYTES, MAX_METADATA_BYTES, AgentRecord, Message, SendResult
+from .models import (
+    MAX_BODY_BYTES,
+    MAX_METADATA_BYTES,
+    MAX_SESSION_ID_LEN,
+    AgentRecord,
+    Message,
+    SendResult,
+)
 
 SCHEMA_PATH: Path = Path(__file__).parent / "schema.sql"
 
@@ -125,6 +132,27 @@ class Store:
             raise ValueError("TARGET_SELF: cannot send to self")
         if len(body.encode("utf-8")) > MAX_BODY_BYTES:
             raise ValueError(f"MESSAGE_TOO_LARGE: body exceeds {MAX_BODY_BYTES} bytes")
+
+        # Extract and validate the optional session_id convention (ADR-001 §4 #2).
+        # The session_id travels inside the caller-supplied ``metadata`` dict so
+        # that no new tool parameter is added to ``agent_send``; the bridge
+        # simply recognises a well-known key, validates it, hoists it into a
+        # dedicated column for query-ability, and leaves the rest of the dict
+        # untouched for opaque forwarding.
+        session_id: str | None = None
+        if metadata is not None and "session_id" in metadata:
+            raw = metadata["session_id"]
+            if raw is not None:
+                if not isinstance(raw, str):
+                    raise ValueError(
+                        "SESSION_ID_INVALID: session_id must be a string"
+                    )
+                if len(raw) > MAX_SESSION_ID_LEN:
+                    raise ValueError(
+                        f"SESSION_ID_TOO_LARGE: session_id exceeds {MAX_SESSION_ID_LEN} chars"
+                    )
+                session_id = raw
+
         metadata_json: str | None = None
         if metadata is not None:
             metadata_json = json.dumps(metadata, separators=(",", ":"))
@@ -139,10 +167,10 @@ class Store:
         now = datetime.now(UTC)
         self._conn.execute(
             """
-            INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at, sender_session_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (message_id, sender, recipient, body, metadata_json, now.isoformat()),
+            (message_id, sender, recipient, body, metadata_json, now.isoformat(), session_id),
         )
         return SendResult(message_id=message_id, sent_at=now, recipient=recipient)
 
@@ -159,7 +187,7 @@ class Store:
             try:
                 rows = self._conn.execute(
                     """
-                    SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                    SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
                     FROM messages
                     WHERE recipient_id = ? AND read_at IS NULL
                     ORDER BY created_at ASC
@@ -177,7 +205,7 @@ class Store:
                     # Re-read to include read_at values in returned objects
                     rows = self._conn.execute(
                         f"""
-                        SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                        SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
                         FROM messages
                         WHERE id IN ({placeholders})
                         ORDER BY created_at ASC
@@ -191,7 +219,7 @@ class Store:
         else:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
                 FROM messages
                 WHERE recipient_id = ?
                 ORDER BY created_at DESC
@@ -209,6 +237,7 @@ class Store:
                 metadata=json.loads(r["metadata"]) if r["metadata"] else None,
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
+                sender_session_id=r["sender_session_id"],
             )
             for r in rows
         ]
@@ -247,7 +276,7 @@ class Store:
         if since_ts is None:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
                 FROM messages
                 WHERE recipient_id = ?
                 ORDER BY created_at DESC
@@ -258,7 +287,7 @@ class Store:
         else:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
                 FROM messages
                 WHERE recipient_id = ? AND created_at >= ?
                 ORDER BY created_at ASC
@@ -276,6 +305,7 @@ class Store:
                 metadata=json.loads(r["metadata"]) if r["metadata"] else None,
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
+                sender_session_id=r["sender_session_id"],
             )
             for r in rows
         ]

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -74,19 +74,7 @@ def tool_agent_inbox(
 ) -> dict[str, Any]:
     store.upsert_agent(caller_id)
     messages = store.read_inbox(caller_id, limit=limit, unread_only=unread_only)
-    return {
-        "messages": [
-            {
-                "message_id": m.id,
-                "sender": m.sender_id,
-                "body": m.body,
-                "metadata": m.metadata,
-                "sent_at": m.created_at.isoformat(),
-                "read_at": m.read_at.isoformat() if m.read_at else None,
-            }
-            for m in messages
-        ]
-    }
+    return {"messages": [_serialize_message(m) for m in messages]}
 
 
 def tool_agent_inbox_peek(
@@ -108,19 +96,7 @@ def tool_agent_inbox_peek(
     """
     store.upsert_agent(caller_id)
     messages = store.peek_inbox(caller_id, since_ts=since_ts, limit=limit)
-    return {
-        "messages": [
-            {
-                "message_id": m.id,
-                "sender": m.sender_id,
-                "body": m.body,
-                "metadata": m.metadata,
-                "sent_at": m.created_at.isoformat(),
-                "read_at": m.read_at.isoformat() if m.read_at else None,
-            }
-            for m in messages
-        ]
-    }
+    return {"messages": [_serialize_message(m) for m in messages]}
 
 
 def tool_agent_list(
@@ -194,4 +170,5 @@ def _serialize_message(m: Any) -> dict[str, Any]:
         "metadata": m.metadata,
         "sent_at": m.created_at.isoformat(),
         "read_at": m.read_at.isoformat() if m.read_at else None,
+        "sender_session_id": m.sender_session_id,
     }

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -129,7 +129,7 @@ def tool_agent_inbox_peek(
     """Read-only inbox view — no mark-as-read, no state mutation.
 
     Thin adapter over :meth:`Store.peek_inbox`; see that method's docstring
-    for semantics. This is the v0.5 primitive added for ADR-001 (Option A′):
+    for semantics. This is the v0.5 primitive added for ADR-001 (Option A'):
     the Hermes gateway uses it to recover its inbox cache after a restart or
     when the cache is lagging behind the bus, and external tooling uses it
     to inspect an agent's history without consuming messages.

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -89,6 +89,40 @@ def tool_agent_inbox(
     }
 
 
+def tool_agent_inbox_peek(
+    store: Store,
+    caller_id: str,
+    since_ts: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Read-only inbox view — no mark-as-read, no state mutation.
+
+    Thin adapter over :meth:`Store.peek_inbox`; see that method's docstring
+    for semantics. This is the v0.5 primitive added for ADR-001 (Option A′):
+    the Hermes gateway uses it to recover its inbox cache after a restart or
+    when the cache is lagging behind the bus, and external tooling uses it
+    to inspect an agent's history without consuming messages.
+
+    The response shape matches :func:`tool_agent_inbox` so callers that
+    already handle the ``messages`` list can switch freely between the two.
+    """
+    store.upsert_agent(caller_id)
+    messages = store.peek_inbox(caller_id, since_ts=since_ts, limit=limit)
+    return {
+        "messages": [
+            {
+                "message_id": m.id,
+                "sender": m.sender_id,
+                "body": m.body,
+                "metadata": m.metadata,
+                "sent_at": m.created_at.isoformat(),
+                "read_at": m.read_at.isoformat() if m.read_at else None,
+            }
+            for m in messages
+        ]
+    }
+
+
 def tool_agent_list(
     store: Store,
     caller_id: str,

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
+from .logging_ext import hash_body, log_event
 from .signals import SignalDir
 from .store import Store
 from .wake import WebhookWaker
@@ -38,6 +40,13 @@ def tool_agent_send(
     Both hooks are best-effort: failures are logged but never propagated — the
     authoritative record is always the SQLite store.
     """
+    start = time.perf_counter()
+    session_id: str | None = None
+    if metadata is not None:
+        sid = metadata.get("session_id")
+        if isinstance(sid, str):
+            session_id = sid
+
     store.upsert_agent(caller_id)
     try:
         result = store.send_message(
@@ -48,7 +57,19 @@ def tool_agent_send(
         )
     except ValueError as e:
         code, _, msg = str(e).partition(":")
-        return {"error": {"code": code.strip() or "ERROR", "message": msg.strip() or str(e)}}
+        err_code = code.strip() or "ERROR"
+        log_event(
+            logger,
+            event="tool.agent_send",
+            agent_id=caller_id,
+            level=logging.WARNING,
+            session_id=session_id,
+            target=target,
+            body_hash=hash_body(message),
+            error_code=err_code,
+            duration_ms=round((time.perf_counter() - start) * 1000, 2),
+        )
+        return {"error": {"code": err_code, "message": msg.strip() or str(e)}}
 
     if signal_dir is not None:
         signal_dir.notify(target)
@@ -59,6 +80,16 @@ def tool_agent_send(
         except Exception as exc:  # pragma: no cover - waker must swallow, defensive
             logger.warning("waker raised for %s: %s", target, exc)
 
+    log_event(
+        logger,
+        event="tool.agent_send",
+        agent_id=caller_id,
+        session_id=session_id,
+        target=target,
+        message_id=result.message_id,
+        body_hash=hash_body(message),
+        duration_ms=round((time.perf_counter() - start) * 1000, 2),
+    )
     return {
         "message_id": result.message_id,
         "sent_at": result.sent_at.isoformat(),
@@ -71,9 +102,20 @@ def tool_agent_inbox(
     caller_id: str,
     limit: int = 10,
     unread_only: bool = True,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
+    start = time.perf_counter()
     store.upsert_agent(caller_id)
     messages = store.read_inbox(caller_id, limit=limit, unread_only=unread_only)
+    log_event(
+        logger,
+        event="tool.agent_inbox",
+        agent_id=caller_id,
+        session_id=session_id,
+        unread_only=unread_only,
+        count=len(messages),
+        duration_ms=round((time.perf_counter() - start) * 1000, 2),
+    )
     return {"messages": [_serialize_message(m) for m in messages]}
 
 
@@ -82,6 +124,7 @@ def tool_agent_inbox_peek(
     caller_id: str,
     since_ts: str | None = None,
     limit: int = 50,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Read-only inbox view — no mark-as-read, no state mutation.
 
@@ -94,8 +137,18 @@ def tool_agent_inbox_peek(
     The response shape matches :func:`tool_agent_inbox` so callers that
     already handle the ``messages`` list can switch freely between the two.
     """
+    start = time.perf_counter()
     store.upsert_agent(caller_id)
     messages = store.peek_inbox(caller_id, since_ts=since_ts, limit=limit)
+    log_event(
+        logger,
+        event="tool.agent_inbox_peek",
+        agent_id=caller_id,
+        session_id=session_id,
+        since_ts=since_ts,
+        count=len(messages),
+        duration_ms=round((time.perf_counter() - start) * 1000, 2),
+    )
     return {"messages": [_serialize_message(m) for m in messages]}
 
 
@@ -103,9 +156,19 @@ def tool_agent_list(
     store: Store,
     caller_id: str,
     active_within_days: int = 7,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
+    start = time.perf_counter()
     store.upsert_agent(caller_id)
     agents = store.list_agents(active_within_days=active_within_days)
+    log_event(
+        logger,
+        event="tool.agent_list",
+        agent_id=caller_id,
+        session_id=session_id,
+        count=len(agents),
+        duration_ms=round((time.perf_counter() - start) * 1000, 2),
+    )
     return {
         "agents": [
             {
@@ -127,6 +190,7 @@ def tool_agent_subscribe(
     timeout_seconds: float = 30.0,
     poll_interval: float = 0.2,
     limit: int = 10,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Long-poll the caller's inbox until a message arrives or timeout expires.
 
@@ -139,6 +203,7 @@ def tool_agent_subscribe(
     ``timed_out`` boolean indicating whether the wait hit its deadline with no
     signal.
     """
+    start = time.perf_counter()
     store.upsert_agent(caller_id)
 
     timeout = max(0.0, min(timeout_seconds, MAX_SUBSCRIBE_TIMEOUT_SECONDS))
@@ -146,6 +211,16 @@ def tool_agent_subscribe(
     # Fast path: messages already waiting → flush & return.
     existing = store.read_inbox(caller_id, limit=limit, unread_only=True)
     if existing:
+        log_event(
+            logger,
+            event="tool.agent_subscribe",
+            agent_id=caller_id,
+            session_id=session_id,
+            timed_out=False,
+            fast_path=True,
+            count=len(existing),
+            duration_ms=round((time.perf_counter() - start) * 1000, 2),
+        )
         return {
             "messages": [_serialize_message(m) for m in existing],
             "timed_out": False,
@@ -153,9 +228,28 @@ def tool_agent_subscribe(
 
     fired = signal_dir.wait(caller_id, timeout_seconds=timeout, poll_interval=poll_interval)
     if not fired:
+        log_event(
+            logger,
+            event="tool.agent_subscribe",
+            agent_id=caller_id,
+            session_id=session_id,
+            timed_out=True,
+            count=0,
+            duration_ms=round((time.perf_counter() - start) * 1000, 2),
+        )
         return {"messages": [], "timed_out": True}
 
     messages = store.read_inbox(caller_id, limit=limit, unread_only=True)
+    log_event(
+        logger,
+        event="tool.agent_subscribe",
+        agent_id=caller_id,
+        session_id=session_id,
+        timed_out=False,
+        fast_path=False,
+        count=len(messages),
+        duration_ms=round((time.perf_counter() - start) * 1000, 2),
+    )
     return {
         "messages": [_serialize_message(m) for m in messages],
         "timed_out": False,

--- a/tests/test_inbox_peek.py
+++ b/tests/test_inbox_peek.py
@@ -1,0 +1,168 @@
+"""Tests for the read-only ``agent_inbox_peek`` primitive (ADR-001 §4 #1).
+
+Contract (keep in sync with the tool docstring in server.py):
+  * peek NEVER mutates ``read_at``
+  * peek returns already-read messages alongside unread ones
+  * when ``since_ts`` is provided, only messages with ``created_at >= since_ts``
+    are returned, sorted ASC by ``created_at``
+  * when ``since_ts`` is omitted, returns the ``limit`` most recent messages
+    sorted DESC by ``created_at`` (newest first)
+  * ``limit`` is clamped to ``[1, 200]``
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.store import Store
+from a2a_mcp_bridge.tools import (
+    tool_agent_inbox,
+    tool_agent_inbox_peek,
+    tool_agent_send,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.sqlite"))
+    s.init_schema()
+    return s
+
+
+def _register(store: Store, *agents: str) -> None:
+    for a in agents:
+        store.upsert_agent(a)
+
+
+class TestAgentInboxPeekIsReadOnly:
+    def test_peek_does_not_mark_read(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="hi-1")
+        tool_agent_send(store, "alice", target="bob", message="hi-2")
+
+        # Peek twice — nothing should change in read_at
+        peek1 = tool_agent_inbox_peek(store, "bob")
+        peek2 = tool_agent_inbox_peek(store, "bob")
+
+        assert len(peek1["messages"]) == 2
+        assert len(peek2["messages"]) == 2
+        assert all(m["read_at"] is None for m in peek1["messages"])
+        assert all(m["read_at"] is None for m in peek2["messages"])
+
+        # And a subsequent unread-only inbox call still sees both messages
+        inbox = tool_agent_inbox(store, "bob", unread_only=True)
+        assert len(inbox["messages"]) == 2
+
+    def test_peek_includes_already_read_messages_with_read_at(
+        self, store: Store
+    ) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="early")
+        tool_agent_send(store, "alice", target="bob", message="late")
+
+        # Consume both via the real inbox
+        inbox = tool_agent_inbox(store, "bob", unread_only=True)
+        assert len(inbox["messages"]) == 2
+
+        # Peek must still see both, with read_at populated
+        peek = tool_agent_inbox_peek(store, "bob")
+        assert len(peek["messages"]) == 2
+        assert all(m["read_at"] is not None for m in peek["messages"])
+
+
+class TestAgentInboxPeekSinceFilter:
+    def test_since_ts_filters_messages_asc(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="old-1")
+        tool_agent_send(store, "alice", target="bob", message="old-2")
+
+        # Sleep enough that created_at is strictly later than the boundary
+        # (ISO string compare is lexicographic but also chronological for
+        # fixed-offset UTC isoformat — sleeping 10ms is plenty for SQLite
+        # to record a later timestamp).
+        time.sleep(0.02)
+        boundary = datetime.now(UTC).isoformat()
+        time.sleep(0.02)
+
+        tool_agent_send(store, "alice", target="bob", message="new-1")
+        tool_agent_send(store, "alice", target="bob", message="new-2")
+
+        peek = tool_agent_inbox_peek(store, "bob", since_ts=boundary)
+        bodies = [m["body"] for m in peek["messages"]]
+        # Only post-boundary messages, in ASC order
+        assert bodies == ["new-1", "new-2"]
+
+    def test_since_ts_in_future_returns_empty(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="now")
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        peek = tool_agent_inbox_peek(store, "bob", since_ts=future)
+        assert peek["messages"] == []
+
+    def test_since_ts_none_returns_latest_desc(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        for i in range(5):
+            tool_agent_send(store, "alice", target="bob", message=f"m{i}")
+            time.sleep(0.005)
+
+        peek = tool_agent_inbox_peek(store, "bob", limit=3)
+        # Newest first, only the 3 most recent
+        bodies = [m["body"] for m in peek["messages"]]
+        assert bodies == ["m4", "m3", "m2"]
+
+
+class TestAgentInboxPeekIsolation:
+    def test_peek_only_shows_messages_addressed_to_caller(self, store: Store) -> None:
+        _register(store, "alice", "bob", "carol")
+        tool_agent_send(store, "alice", target="bob", message="for-bob")
+        tool_agent_send(store, "alice", target="carol", message="for-carol")
+
+        peek_bob = tool_agent_inbox_peek(store, "bob")
+        peek_carol = tool_agent_inbox_peek(store, "carol")
+
+        assert [m["body"] for m in peek_bob["messages"]] == ["for-bob"]
+        assert [m["body"] for m in peek_carol["messages"]] == ["for-carol"]
+
+    def test_peek_respects_limit_clamp(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="only-one")
+
+        # limit=0 → clamped to 1 (at least one message returned)
+        peek_zero = tool_agent_inbox_peek(store, "bob", limit=0)
+        assert len(peek_zero["messages"]) == 1
+
+        # limit=9999 → accepted (clamped to 200 internally, but we have 1 msg)
+        peek_huge = tool_agent_inbox_peek(store, "bob", limit=9999)
+        assert len(peek_huge["messages"]) == 1
+
+
+class TestAgentInboxPeekPayloadShape:
+    def test_payload_shape_matches_inbox(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="shape",
+            metadata={"topic": "ping"},
+        )
+
+        peek = tool_agent_inbox_peek(store, "bob")
+        assert len(peek["messages"]) == 1
+        m = peek["messages"][0]
+        # Same keys as agent_inbox's serialisation
+        assert set(m.keys()) == {
+            "message_id",
+            "sender",
+            "body",
+            "metadata",
+            "sent_at",
+            "read_at",
+        }
+        assert m["sender"] == "alice"
+        assert m["metadata"] == {"topic": "ping"}
+        assert m["read_at"] is None  # peek doesn't mark read

--- a/tests/test_inbox_peek.py
+++ b/tests/test_inbox_peek.py
@@ -154,7 +154,7 @@ class TestAgentInboxPeekPayloadShape:
         peek = tool_agent_inbox_peek(store, "bob")
         assert len(peek["messages"]) == 1
         m = peek["messages"][0]
-        # Same keys as agent_inbox's serialisation
+        # Same keys as agent_inbox's serialisation (now includes sender_session_id)
         assert set(m.keys()) == {
             "message_id",
             "sender",
@@ -162,7 +162,9 @@ class TestAgentInboxPeekPayloadShape:
             "metadata",
             "sent_at",
             "read_at",
+            "sender_session_id",
         }
         assert m["sender"] == "alice"
         assert m["metadata"] == {"topic": "ping"}
         assert m["read_at"] is None  # peek doesn't mark read
+        assert m["sender_session_id"] is None  # none provided on send

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,221 @@
+"""Tests for session-tagged structured logging (ADR-001 §4 #3, v0.5).
+
+The bridge must emit one log record per tool call with a minimum schema:
+``{ts, level, event, agent_id}``, plus ``session_id`` when provided. Bodies
+and caller metadata are never logged verbatim — only a short
+:func:`hash_body` digest goes into ``body_hash``.
+
+Toggling is done via ``A2A_LOG_JSON=1`` but is evaluated at import time, so
+we don't flip it live in tests; we test the two code paths independently:
+
+* the ``log_event`` helper's output under both modes (pure unit)
+* the integration flow (tool handlers emit the expected event names and
+  carry the session_id when provided)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge import logging_ext
+from a2a_mcp_bridge.logging_ext import hash_body
+from a2a_mcp_bridge.store import Store
+from a2a_mcp_bridge.tools import (
+    tool_agent_inbox,
+    tool_agent_inbox_peek,
+    tool_agent_list,
+    tool_agent_send,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.sqlite"))
+    s.init_schema()
+    return s
+
+
+def _register(store: Store, *agents: str) -> None:
+    for a in agents:
+        store.upsert_agent(a)
+
+
+class TestHashBody:
+    def test_hash_body_is_stable_and_short(self) -> None:
+        assert hash_body("hello") == hash_body("hello")
+        assert len(hash_body("hello")) == 16  # 8-byte blake2b → 16 hex chars
+
+    def test_hash_body_handles_none_and_bytes(self) -> None:
+        assert hash_body(None) is None
+        assert hash_body(b"raw") == hash_body("raw")
+
+    def test_hash_body_distinguishes_bodies(self) -> None:
+        assert hash_body("one") != hash_body("two")
+
+
+class TestLogEventPlainText:
+    def test_plain_text_emits_event_and_kv_pairs(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Force plain-text mode (default) — reimport to re-read env
+        monkeypatch.setenv("A2A_LOG_JSON", "")
+        importlib.reload(logging_ext)
+
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tests")
+        test_logger = logging.getLogger("a2a_mcp_bridge.tests")
+        logging_ext.log_event(
+            test_logger,
+            event="tool.test",
+            agent_id="alice",
+            session_id="s1",
+            target="bob",
+            count=3,
+        )
+        records = [r for r in caplog.records if r.name == "a2a_mcp_bridge.tests"]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert msg.startswith("tool.test ")
+        assert "[session=s1]" in msg
+        assert "target=bob" in msg
+        assert "count=3" in msg
+
+    def test_plain_text_drops_none_fields(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("A2A_LOG_JSON", "")
+        importlib.reload(logging_ext)
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tests")
+        test_logger = logging.getLogger("a2a_mcp_bridge.tests")
+        logging_ext.log_event(
+            test_logger,
+            event="tool.test",
+            agent_id="alice",
+            session_id=None,  # absent from output
+            count=0,  # present — 0 is not None
+            body_hash=None,  # absent
+        )
+        msg = [r for r in caplog.records if r.name == "a2a_mcp_bridge.tests"][
+            -1
+        ].getMessage()
+        assert "session=" not in msg
+        assert "body_hash" not in msg
+        assert "count=0" in msg
+
+
+class TestLogEventJson:
+    def test_json_mode_emits_object_per_line(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("A2A_LOG_JSON", "1")
+        importlib.reload(logging_ext)
+
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tests")
+        test_logger = logging.getLogger("a2a_mcp_bridge.tests")
+        logging_ext.log_event(
+            test_logger,
+            event="tool.test",
+            agent_id="alice",
+            session_id="s1",
+            message_id="abcd",
+            duration_ms=4.2,
+        )
+        records = [r for r in caplog.records if r.name == "a2a_mcp_bridge.tests"]
+        assert len(records) == 1
+        payload = json.loads(records[0].getMessage())
+
+        # Minimum schema always present
+        for k in ("ts", "level", "event", "agent_id"):
+            assert k in payload
+        assert payload["event"] == "tool.test"
+        assert payload["agent_id"] == "alice"
+        assert payload["session_id"] == "s1"
+        assert payload["message_id"] == "abcd"
+        assert payload["duration_ms"] == 4.2
+
+        # Reset back to default for other tests
+        monkeypatch.setenv("A2A_LOG_JSON", "")
+        importlib.reload(logging_ext)
+
+
+class TestToolIntegration:
+    def test_agent_send_logs_event_with_session_id(
+        self, store: Store, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _register(store, "alice", "bob")
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tools")
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="hello",
+            metadata={"session_id": "sess-42"},
+        )
+        assert "error" not in result
+
+        msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "a2a_mcp_bridge.tools"
+        ]
+        # At least one tool.agent_send line carrying the session_id
+        assert any(
+            "tool.agent_send" in m and "session=sess-42" in m for m in msgs
+        )
+        # body_hash appears (and is 16 hex chars), body content does not
+        assert any(f"body_hash={hash_body('hello')}" in m for m in msgs)
+        assert not any("hello" in m for m in msgs)  # body never leaks in a log line
+
+    def test_agent_send_error_logs_warn(
+        self, store: Store, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _register(store, "alice")
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tools")
+        result = tool_agent_send(store, "alice", target="ghost", message="x")
+        assert result["error"]["code"] == "TARGET_UNKNOWN"
+
+        records = [r for r in caplog.records if r.name == "a2a_mcp_bridge.tools"]
+        err_records = [r for r in records if r.levelno == logging.WARNING]
+        assert err_records, "expected a WARNING log record on agent_send error"
+        msg = err_records[-1].getMessage()
+        assert "tool.agent_send" in msg
+        assert "error_code=TARGET_UNKNOWN" in msg
+
+    def test_read_tools_pick_up_session_id_param(
+        self, store: Store, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _register(store, "alice", "bob")
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tools")
+
+        # exercise each read tool with session_id
+        tool_agent_inbox(store, "bob", session_id="s-inbox")
+        tool_agent_inbox_peek(store, "bob", session_id="s-peek")
+        tool_agent_list(store, "bob", session_id="s-list")
+
+        records = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "a2a_mcp_bridge.tools"
+        ]
+        assert any("tool.agent_inbox " in m and "session=s-inbox" in m for m in records)
+        assert any(
+            "tool.agent_inbox_peek" in m and "session=s-peek" in m for m in records
+        )
+        assert any("tool.agent_list" in m and "session=s-list" in m for m in records)
+
+    def test_tool_logs_always_include_duration(
+        self, store: Store, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _register(store, "alice", "bob")
+        caplog.set_level(logging.INFO, logger="a2a_mcp_bridge.tools")
+        tool_agent_list(store, "alice")
+        msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "a2a_mcp_bridge.tools" and "tool.agent_list" in r.getMessage()
+        ]
+        assert any("duration_ms=" in m for m in msgs)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,156 @@
+"""Tests for idempotent schema migrations applied by :meth:`Store.init_schema`.
+
+The v0.5 migration adds ``messages.sender_session_id`` to databases that
+pre-date the column. We verify:
+
+* a fresh DB already carries the column (via the updated ``schema.sql``);
+* a DB created from the legacy v0.4 schema has the column added on init,
+  without losing existing rows;
+* a second ``init_schema`` call on a migrated DB is a no-op (idempotent).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.store import Store
+
+
+LEGACY_V04_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agents (
+    id TEXT PRIMARY KEY,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    sender_id TEXT NOT NULL,
+    recipient_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    metadata TEXT,
+    created_at TEXT NOT NULL,
+    read_at TEXT,
+    FOREIGN KEY (sender_id) REFERENCES agents(id),
+    FOREIGN KEY (recipient_id) REFERENCES agents(id)
+);
+"""
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _seed_legacy_db(db_path: Path) -> None:
+    """Create a DB with the pre-v0.5 schema and one message in it."""
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.executescript(LEGACY_V04_SCHEMA)
+        now = datetime.now(UTC).isoformat()
+        conn.execute(
+            "INSERT INTO agents (id, first_seen_at, last_seen_at, metadata) VALUES (?, ?, ?, NULL)",
+            ("alice", now, now),
+        )
+        conn.execute(
+            "INSERT INTO agents (id, first_seen_at, last_seen_at, metadata) VALUES (?, ?, ?, NULL)",
+            ("bob", now, now),
+        )
+        conn.execute(
+            """
+            INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (uuid.uuid4().hex, "alice", "bob", "legacy", None, now),
+        )
+    finally:
+        conn.close()
+
+
+class TestSenderSessionIdMigration:
+    def test_fresh_db_has_sender_session_id_column(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.sqlite"
+        store = Store(str(db_path))
+        store.init_schema()
+        try:
+            assert "sender_session_id" in _columns(store._conn, "messages")
+        finally:
+            store.close()
+
+    def test_legacy_db_gets_column_added_without_data_loss(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "legacy.sqlite"
+        _seed_legacy_db(db_path)
+
+        # Sanity check — pre-migration state
+        conn = sqlite3.connect(str(db_path))
+        assert "sender_session_id" not in _columns(conn, "messages")
+        pre_rows = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        conn.close()
+        assert pre_rows == 1
+
+        # Migrate
+        store = Store(str(db_path))
+        store.init_schema()
+        try:
+            # Column exists, existing rows still present, sender_session_id NULL on old row
+            assert "sender_session_id" in _columns(store._conn, "messages")
+            rows = store._conn.execute(
+                "SELECT body, sender_session_id FROM messages"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0]["body"] == "legacy"
+            assert rows[0]["sender_session_id"] is None
+        finally:
+            store.close()
+
+    def test_migration_is_idempotent(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "repeat.sqlite"
+        _seed_legacy_db(db_path)
+
+        # First init — adds column
+        store = Store(str(db_path))
+        store.init_schema()
+        store.close()
+
+        # Second init on the same file — must not raise and must leave state intact
+        store = Store(str(db_path))
+        store.init_schema()
+        try:
+            assert "sender_session_id" in _columns(store._conn, "messages")
+            rows = store._conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+            assert rows[0] == 1
+        finally:
+            store.close()
+
+    def test_migration_does_not_break_existing_send_read_flow(
+        self, tmp_path: Path
+    ) -> None:
+        """After migration the canonical send/read flow still behaves as before."""
+        db_path = tmp_path / "flow.sqlite"
+        _seed_legacy_db(db_path)
+
+        store = Store(str(db_path))
+        store.init_schema()
+        try:
+            store.send_message(sender="alice", recipient="bob", body="post-migration")
+            unread = store.read_inbox(agent_id="bob", unread_only=True)
+            bodies = [m.body for m in unread]
+            # Both the legacy row and the post-migration row are deliverable
+            assert "legacy" in bodies
+            assert "post-migration" in bodies
+        finally:
+            store.close()
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.sqlite"))
+    s.init_schema()
+    return s

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -20,7 +20,6 @@ import pytest
 
 from a2a_mcp_bridge.store import Store
 
-
 LEGACY_V04_SCHEMA = """
 CREATE TABLE IF NOT EXISTS agents (
     id TEXT PRIMARY KEY,

--- a/tests/test_session_id.py
+++ b/tests/test_session_id.py
@@ -1,0 +1,174 @@
+"""Tests for the optional ``session_id`` metadata convention (ADR-001 §4 #2).
+
+Contract:
+  * ``agent_send`` recognises a ``session_id`` key inside the opaque
+    ``metadata`` dict. No new tool parameter.
+  * The value must be a string ≤ 128 chars — otherwise the send is rejected
+    with ``SESSION_ID_INVALID`` or ``SESSION_ID_TOO_LARGE``.
+  * On success, ``sender_session_id`` is stored in the dedicated SQLite
+    column AND surfaced at the top level of the payload returned by
+    ``agent_inbox`` / ``agent_inbox_peek``.
+  * Absence of the key (or ``session_id=None``) leaves the column NULL and
+    the payload key at ``None`` — nothing breaks for pre-v0.5 callers.
+  * The rest of the metadata dict is preserved for opaque forwarding.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.store import Store
+from a2a_mcp_bridge.tools import (
+    tool_agent_inbox,
+    tool_agent_inbox_peek,
+    tool_agent_send,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.sqlite"))
+    s.init_schema()
+    return s
+
+
+def _register(store: Store, *agents: str) -> None:
+    for a in agents:
+        store.upsert_agent(a)
+
+
+class TestSessionIdPropagation:
+    def test_session_id_propagates_to_inbox_payload(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="hi",
+            metadata={"session_id": "sess-abc-123", "topic": "hello"},
+        )
+        assert "error" not in result
+
+        inbox = tool_agent_inbox(store, "bob")
+        assert len(inbox["messages"]) == 1
+        msg = inbox["messages"][0]
+        assert msg["sender_session_id"] == "sess-abc-123"
+        # The session_id is preserved in metadata too (opaque forwarding)
+        assert msg["metadata"] == {"session_id": "sess-abc-123", "topic": "hello"}
+
+    def test_session_id_propagates_to_peek_payload(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="hi",
+            metadata={"session_id": "peek-session-42"},
+        )
+        peek = tool_agent_inbox_peek(store, "bob")
+        assert len(peek["messages"]) == 1
+        assert peek["messages"][0]["sender_session_id"] == "peek-session-42"
+
+    def test_no_session_id_leaves_column_and_payload_null(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        # No metadata at all
+        tool_agent_send(store, "alice", target="bob", message="no-meta")
+        # Metadata without session_id
+        tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="no-session",
+            metadata={"topic": "other"},
+        )
+        # Explicit session_id=None
+        tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="null-session",
+            metadata={"session_id": None, "other": "k"},
+        )
+
+        inbox = tool_agent_inbox(store, "bob", unread_only=True, limit=10)
+        assert len(inbox["messages"]) == 3
+        assert all(m["sender_session_id"] is None for m in inbox["messages"])
+
+
+class TestSessionIdValidation:
+    def test_rejects_non_string_session_id(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="x",
+            metadata={"session_id": 12345},
+        )
+        assert result.get("error", {}).get("code") == "SESSION_ID_INVALID"
+
+    def test_rejects_too_long_session_id(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        too_long = "a" * 129
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="x",
+            metadata={"session_id": too_long},
+        )
+        assert result.get("error", {}).get("code") == "SESSION_ID_TOO_LARGE"
+
+    def test_accepts_exactly_max_length(self, store: Store) -> None:
+        _register(store, "alice", "bob")
+        max_id = "a" * 128
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="x",
+            metadata={"session_id": max_id},
+        )
+        assert "error" not in result
+
+        inbox = tool_agent_inbox(store, "bob")
+        assert inbox["messages"][0]["sender_session_id"] == max_id
+
+    def test_accepts_empty_string(self, store: Store) -> None:
+        """Empty string is a valid (but pointless) session_id — don't reject it."""
+        _register(store, "alice", "bob")
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="x",
+            metadata={"session_id": ""},
+        )
+        assert "error" not in result
+        inbox = tool_agent_inbox(store, "bob")
+        assert inbox["messages"][0]["sender_session_id"] == ""
+
+
+class TestSessionIdBackwardCompat:
+    def test_existing_inbox_shape_unchanged_without_session_id(
+        self, store: Store
+    ) -> None:
+        """Pre-v0.5 callers see ``sender_session_id: None`` and that's it."""
+        _register(store, "alice", "bob")
+        tool_agent_send(store, "alice", target="bob", message="hi")
+
+        inbox = tool_agent_inbox(store, "bob")
+        m = inbox["messages"][0]
+        expected_keys = {
+            "message_id",
+            "sender",
+            "body",
+            "metadata",
+            "sent_at",
+            "read_at",
+            "sender_session_id",
+        }
+        assert set(m.keys()) == expected_keys
+        assert m["sender_session_id"] is None

--- a/tests/test_session_id.py
+++ b/tests/test_session_id.py
@@ -3,8 +3,10 @@
 Contract:
   * ``agent_send`` recognises a ``session_id`` key inside the opaque
     ``metadata`` dict. No new tool parameter.
-  * The value must be a string ≤ 128 chars — otherwise the send is rejected
-    with ``SESSION_ID_INVALID`` or ``SESSION_ID_TOO_LARGE``.
+  * The value must be a string whose UTF-8 encoding is ≤ 128 bytes —
+    otherwise the send is rejected with ``SESSION_ID_INVALID`` or
+    ``SESSION_ID_TOO_LARGE``. The limit is enforced in BYTES (not chars)
+    so UTF-8 multi-byte characters (emoji, CJK) cannot sneak past.
   * On success, ``sender_session_id`` is stored in the dedicated SQLite
     column AND surfaced at the top level of the payload returned by
     ``agent_inbox`` / ``agent_inbox_peek``.
@@ -111,7 +113,7 @@ class TestSessionIdValidation:
 
     def test_rejects_too_long_session_id(self, store: Store) -> None:
         _register(store, "alice", "bob")
-        too_long = "a" * 129
+        too_long = "a" * 129  # 129 ASCII bytes
         result = tool_agent_send(
             store,
             "alice",
@@ -121,9 +123,29 @@ class TestSessionIdValidation:
         )
         assert result.get("error", {}).get("code") == "SESSION_ID_TOO_LARGE"
 
+    def test_rejects_utf8_that_exceeds_bytes_limit(self, store: Store) -> None:
+        """GLM review nit #1 regression guard.
+
+        The limit is enforced in BYTES (len(raw.encode("utf-8"))), not
+        characters. A string of 33 4-byte emoji is 33 chars but 132 bytes,
+        so it must be rejected even though len() = 33 ≤ 128.
+        """
+        _register(store, "alice", "bob")
+        emoji_33 = "🎯" * 33  # 33 chars, 132 bytes in UTF-8
+        assert len(emoji_33) == 33
+        assert len(emoji_33.encode("utf-8")) == 132
+        result = tool_agent_send(
+            store,
+            "alice",
+            target="bob",
+            message="x",
+            metadata={"session_id": emoji_33},
+        )
+        assert result.get("error", {}).get("code") == "SESSION_ID_TOO_LARGE"
+
     def test_accepts_exactly_max_length(self, store: Store) -> None:
         _register(store, "alice", "bob")
-        max_id = "a" * 128
+        max_id = "a" * 128  # 128 ASCII bytes = 128 bytes
         result = tool_agent_send(
             store,
             "alice",


### PR DESCRIPTION
## v0.5 — Bridge primitives

Implements ADR-001 Option A' (leader-at-gateway) and the supporting primitives for multi-session concurrency.

### Chantiers

- **c1** `03c8d87` — idempotent migration `messages.sender_session_id` (SQLite `ALTER TABLE ADD COLUMN`, legacy-compat)
- **c2** `6b6f432` — `agent_inbox_peek` read-only primitive (non-destructive inbox view, no `read_at` side-effect)
- **c3** `e96be7e` — `agent_send` propagates optional `session_id` from metadata into the message row
- **c4** `d3bd7e5` — structured session-tagged log events (ADR-001 §4 #3): `log_event(logger, *, event, agent_id, session_id, **fields)`, JSON output gated by `A2A_LOG_JSON=1`, `hash_body()` PII-safe digest helper
- **chore** `928a03b` — bump 0.5.0 + CHANGELOG + docstring polish + `A′→A'` ASCII typo fix

### Test coverage

| Suite | Tests |
|---|---|
| `test_migrations.py` | 4 (fresh / legacy-full / idempotent / post-migration flow) |
| `test_inbox_peek.py` | 8 |
| `test_session_id.py` | 8 |
| `test_logging.py` | 10 |
| **Full suite** | **146/146 ✅** |

### Gates

- `pytest -q` : 146/146 ✅
- `ruff check src/ tests/` : clean ✅
- `mypy --strict` on new code (`logging_ext.py`, `tools.py`) : 0 error ✅
- Net LOC src/ : ~445 (under 500 gate) ✅
- Tests LOC : 720 (out of budget per convention)

### Design notes

- **No `JsonFormatter` / handler installer** — `logging_ext` is function-centric (`log_event`) to avoid root-logger mutation and keep import side-effects to a single `A2A_LOG_JSON` env read.
- **`hash_body()`** uses `blake2b(digest_size=8)` for PII-safe message digest in logs.
- **c5/c6 not in scope** — will land in a follow-up PR to keep this one reviewable in a single pass.

### Reviewers

- @vlbeau-glm51 for the deep review (pre-check already LGTM, gates green locally)

cc @vlefebvre21

— Qwen (vlbeau-qwen36)