### PR TITLE
fix(v0.5.1): agent_inbox clears signal file after consuming read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-23
+
+**Theme** — signal cleanup bugfix for `agent_inbox` + `agent_subscribe` wake-up
+correctness. A consuming read (`agent_inbox` with `unread_only=True`) now
+clears the per-agent signal file, so a subsequent `agent_subscribe` waits for
+the next real send instead of fast-pathing on a stale signal with an empty
+inbox.
+
+### Fixed
+- **`agent_inbox` leaves stale signal file after consuming read** — before
+  v0.5.1, `agent_inbox(unread_only=True)` drained unread messages from the
+  SQLite store but left `<signal_dir>/<agent_id>.notify` in place. A
+  subsequent `agent_subscribe` call then hit the fast-path in
+  `SignalDir.wait()` (which consumes the pre-existing signal) and returned
+  immediately with `messages=[]` and `timed_out=False`, breaking the real-time
+  wake-up contract. Now `tool_agent_inbox` clears the signal file via a new
+  `SignalDir.clear(agent_id)` method when the read consumed at least one
+  message (`unread_only=True and count > 0`). `agent_inbox_peek` does NOT
+  clear (it is a read-only view by design — see ADR-001 Option A′).
+
+### Added
+- **`SignalDir.clear(agent_id)`** — new best-effort helper that removes the
+  agent's signal file if present. Idempotent (no-op if the file does not
+  exist), and swallows `FileNotFoundError` / other `OSError` kinds so a
+  signal failure never blocks the canonical inbox read.
+
+### Changed
+- **`tool_agent_inbox` signature** — gained optional `signal_dir: SignalDir
+  | None = None` kwarg. Backwards-compatible: existing callers (unit tests,
+  v0.5 clients that don't pass the wiring) continue to work, they just don't
+  get the cleanup behaviour. The server closure in `build_server` wires it
+  automatically.
+
+### Tests
+- 7 new tests in `TestSignalCleanupV051` covering `SignalDir.clear`
+  idempotence, consuming-read cleanup, empty-read non-interference,
+  `agent_inbox_peek` signal preservation, backwards-compat without
+  `signal_dir`, and an end-to-end regression test
+  (`test_subscribe_after_inbox_drain_waits_for_fresh_signal`) that asserts
+  the core v0.5.1 invariant: `send → inbox (drain) → send2 → subscribe`
+  wakes on the NEW signal with `timed_out=False`, not fast-path on a
+  pre-drain residual.
+
+### Deferred
+- **ADR-001 §4 deprecation of `agent_subscribe` for Hermes gateway sessions**
+  — this was discussed during v0.5.1 triage but intentionally split into a
+  separate documentation PR (post-merge of this bugfix) so the bugfix stays
+  cherry-pickable and the policy shift gets its own round of review. See
+  follow-up branch `docs/adr-001-deprecate-subscribe-for-sessions`.
+
 ## [0.5.0] - 2026-04-23
 
 **Theme** — bridge-side primitives for multi-session concurrency (ADR-001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -238,6 +238,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             limit=limit,
             unread_only=unread_only,
             session_id=session_id,
+            signal_dir=signal_dir,
         )
 
     @mcp.tool()

--- a/src/a2a_mcp_bridge/signals.py
+++ b/src/a2a_mcp_bridge/signals.py
@@ -51,6 +51,25 @@ class SignalDir:
         except OSError as exc:  # pragma: no cover - defensive
             logger.warning("failed to write signal file %s: %s", target, exc)
 
+    def clear(self, agent_id: str) -> None:
+        """Remove the signal file for ``agent_id`` if it exists.
+
+        Called by ``tool_agent_inbox`` after a consuming read (``unread_only=True``
+        with at least one message returned) so that the next ``agent_subscribe``
+        does NOT fast-path on a stale signal whose unread messages have just been
+        drained. See the v0.5.1 signal-cleanup bugfix rationale: without this the
+        subscribe loop returns immediately with an empty ``messages=[]`` and
+        ``timed_out=False``, breaking wake-up semantics.
+
+        Best-effort — a concurrent reader in the same profile (post-v0.5
+        multi-session) may race us to remove. ``FileNotFoundError`` is suppressed
+        explicitly; other ``OSError`` kinds are suppressed defensively as well
+        because a signal failure must never block the canonical inbox read.
+        """
+        target = signal_path_for(self.path, agent_id)
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.remove(target)
+
     def wait(
         self,
         agent_id: str,

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -103,10 +103,23 @@ def tool_agent_inbox(
     limit: int = 10,
     unread_only: bool = True,
     session_id: str | None = None,
+    signal_dir: SignalDir | None = None,
 ) -> dict[str, Any]:
     start = time.perf_counter()
     store.upsert_agent(caller_id)
     messages = store.read_inbox(caller_id, limit=limit, unread_only=unread_only)
+    # v0.5.1 — clear the signal file after a consuming read so a subsequent
+    # ``agent_subscribe`` does not fast-path on a stale signal whose unread
+    # messages have just been drained. We only clear when:
+    #   * a ``signal_dir`` is wired (omitted in unit tests with no real fs)
+    #   * the read was consuming (``unread_only=True`` — mark-as-read happened)
+    #   * at least one message was returned (nothing to drain otherwise; also
+    #     avoids masking a future send's signal that arrived between the store
+    #     read and this point — see docstring of ``SignalDir.clear``).
+    # ``peek_inbox`` (``tool_agent_inbox_peek``) NEVER clears the signal because
+    # it does not mutate ``read_at``.
+    if signal_dir is not None and unread_only and messages:
+        signal_dir.clear(caller_id)
     log_event(
         logger,
         event="tool.agent_inbox",

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -11,6 +11,7 @@ import pytest
 from a2a_mcp_bridge.signals import SignalDir, signal_path_for
 from a2a_mcp_bridge.store import Store
 from a2a_mcp_bridge.tools import (
+    tool_agent_inbox,
     tool_agent_send,
     tool_agent_subscribe,
 )
@@ -177,3 +178,131 @@ class TestAgentSubscribe:
         )
         assert (time.monotonic() - start) < 1.0
         assert result["timed_out"] is True
+
+
+class TestSignalCleanupV051:
+    """v0.5.1 bugfix — ``tool_agent_inbox`` must drop the signal after a consuming
+    read so the next ``agent_subscribe`` does not fast-path on a stale signal.
+    """
+
+    def test_clear_removes_signal_file(self, signal_dir: SignalDir) -> None:
+        signal_dir.notify("alice")
+        path = signal_path_for(signal_dir.path, "alice")
+        assert path.is_file()
+        signal_dir.clear("alice")
+        assert not path.exists()
+
+    def test_clear_is_idempotent_no_signal(self, signal_dir: SignalDir) -> None:
+        """clear() on a non-existent signal is a silent no-op (no FileNotFoundError)."""
+        path = signal_path_for(signal_dir.path, "ghost")
+        assert not path.exists()
+        signal_dir.clear("ghost")  # must not raise
+        assert not path.exists()
+
+    def test_inbox_clears_signal_on_consuming_read(
+        self, store: Store, signal_dir: SignalDir
+    ) -> None:
+        """After ``tool_agent_inbox(unread_only=True)`` drains messages, the signal
+        file must be gone so the next ``agent_subscribe`` waits for a fresh send.
+        """
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+        tool_agent_send(store, "alice", target="bob", message="m1", signal_dir=signal_dir)
+        assert signal_path_for(signal_dir.path, "bob").is_file()
+
+        result = tool_agent_inbox(
+            store, "bob", unread_only=True, signal_dir=signal_dir
+        )
+        assert len(result["messages"]) == 1
+        assert not signal_path_for(signal_dir.path, "bob").exists()
+
+    def test_inbox_does_not_clear_when_empty(
+        self, store: Store, signal_dir: SignalDir
+    ) -> None:
+        """Empty consuming read must NOT touch an external signal that arrived
+        concurrently (nothing to drain, and a future send's signal could be racing).
+        """
+        store.upsert_agent("alice")
+        # External signal from a send whose row hasn't committed yet (contrived,
+        # but captures the invariant): inbox read returns [], signal stays.
+        signal_dir.notify("alice")
+        result = tool_agent_inbox(
+            store, "alice", unread_only=True, signal_dir=signal_dir
+        )
+        assert result["messages"] == []
+        assert signal_path_for(signal_dir.path, "alice").is_file()
+
+    def test_inbox_peek_never_clears_signal(
+        self, store: Store, signal_dir: SignalDir
+    ) -> None:
+        """``agent_inbox_peek`` (non-consuming) must leave the signal alone even
+        if messages are returned.
+        """
+        from a2a_mcp_bridge.tools import tool_agent_inbox_peek
+
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+        tool_agent_send(store, "alice", target="bob", message="m1", signal_dir=signal_dir)
+        assert signal_path_for(signal_dir.path, "bob").is_file()
+
+        # Peek returns the message but does not mutate state.
+        result = tool_agent_inbox_peek(store, "bob")
+        assert len(result["messages"]) == 1
+        assert signal_path_for(signal_dir.path, "bob").is_file()
+
+    def test_inbox_without_signal_dir_is_backwards_compat(self, store: Store) -> None:
+        """Callers that don't pass ``signal_dir`` (unit tests, v0.5 clients) still work."""
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+        store.send_message("alice", "bob", "hello")
+        result = tool_agent_inbox(store, "bob", unread_only=True)
+        assert len(result["messages"]) == 1
+
+    def test_subscribe_after_inbox_drain_waits_for_fresh_signal(
+        self, store: Store, signal_dir: SignalDir
+    ) -> None:
+        """End-to-end regression for the v0.5.1 bug:
+        send → inbox (consume) → send2 → subscribe must resolve on the NEW signal
+        with ``messages=[msg2]`` AND ``timed_out=False``, not fast-path on a stale
+        pre-drain signal.
+        """
+        db_path = store.db_path
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+
+        # 1st round: send → inbox drains it → signal should be cleared.
+        tool_agent_send(store, "alice", target="bob", message="m1", signal_dir=signal_dir)
+        drain = tool_agent_inbox(store, "bob", unread_only=True, signal_dir=signal_dir)
+        assert len(drain["messages"]) == 1
+        assert not signal_path_for(signal_dir.path, "bob").exists(), (
+            "v0.5.1 invariant: agent_inbox must clear the signal after consuming read"
+        )
+
+        # 2nd round: schedule a send slightly after subscribe starts; subscribe must
+        # wake on the NEW signal, not return stale empty from a residual file.
+        def send_after_delay() -> None:
+            sender_store = Store(db_path)
+            time.sleep(0.2)
+            tool_agent_send(
+                sender_store, "alice", target="bob", message="m2", signal_dir=signal_dir
+            )
+            sender_store.close()
+
+        threading.Thread(target=send_after_delay, daemon=True).start()
+        start = time.monotonic()
+        result = tool_agent_subscribe(
+            store,
+            "bob",
+            signal_dir=signal_dir,
+            timeout_seconds=3.0,
+            poll_interval=0.05,
+        )
+        elapsed = time.monotonic() - start
+
+        # Core assertions: fresh wake, not stale-signal fast-path.
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["body"] == "m2"
+        assert result["timed_out"] is False
+        # Must have actually waited for the delayed send (not returned < 50ms on
+        # fast-path of a stale signal).
+        assert elapsed >= 0.15, f"expected to wait for fresh signal, got {elapsed:.3f}s"


### PR DESCRIPTION
## Summary

Fix the v0.5 wake-up regression where `agent_inbox(unread_only=True)` drains unread messages from the SQLite store but leaves `<signal_dir>/<agent_id>.notify` in place. A subsequent `agent_subscribe` then hits the fast-path in `SignalDir.wait()`, consumes the stale signal, and returns immediately with `messages=[]` and `timed_out=False` — silently breaking real-time wake-up semantics.

## Root cause (byte-by-byte)

1. `tool_agent_send` → `signal_dir.notify(target)` writes `<target>.notify`
2. `tool_agent_inbox(unread_only=True)` marks messages read in SQLite but **does not touch the signal file**
3. Next `agent_subscribe(target)` → `SignalDir.wait()` sees the residual `.notify`, `os.remove`s it, returns `True`
4. The caller then reads the inbox, finds nothing new, and returns `{messages: [], timed_out: False}` — the opposite of the intended contract (either wait, or return new messages).

## Fix

- New `SignalDir.clear(agent_id)` — best-effort idempotent removal of the signal file (suppresses `FileNotFoundError` + `OSError` to match the rest of the module's never-block-the-read philosophy).
- `tool_agent_inbox` gains an optional `signal_dir: SignalDir | None = None` kwarg; clears the signal only when `unread_only=True and messages` (see inline comment for the invariant rationale — an empty consuming read must not mask a concurrent send's fresh signal).
- `agent_inbox_peek` **never** clears — it is the read-only view by ADR-001 Option A' design.
- `build_server` wires the existing `signal_dir` closure through the new kwarg.
- Backwards-compatible: callers that don't pass `signal_dir` (unit tests, v0.5 clients with no wiring) keep working without the cleanup.

## Tests

`TestSignalCleanupV051` (7 new tests):
- `test_clear_removes_signal_file` — basic clear() happy path
- `test_clear_is_idempotent_no_signal` — clear() on missing file is silent
- `test_inbox_clears_signal_on_consuming_read` — unit of the fix
- `test_inbox_does_not_clear_when_empty` — empty read preserves a concurrent signal
- `test_inbox_peek_never_clears_signal` — peek's read-only contract
- `test_inbox_without_signal_dir_is_backwards_compat` — no `signal_dir` kwarg still works
- `test_subscribe_after_inbox_drain_waits_for_fresh_signal` — **end-to-end regression**: `send → inbox (drain) → send2 → subscribe` wakes on the NEW signal with `timed_out=False`, asserts `elapsed >= 0.15s` so a fast-path on a stale residual would fail the test

Full suite: **150/150 green**. `ruff check` + `mypy` clean.

## Bump

- `pyproject.toml`: `0.5.0` → `0.5.1`
- `CHANGELOG.md`: new `[0.5.1]` section

## Deferred (follow-up PR)

ADR-001 §4 deprecation of `agent_subscribe` for Hermes gateway sessions — discussed during triage, intentionally split so this bugfix stays cherry-pickable and the policy shift gets its own review round (glm51/deepseek may want to weigh in). Branch: `docs/adr-001-deprecate-subscribe-for-sessions` (to come).

## Out of scope (noted)

Bug #2 from the original triage — silent message loss when reading via Telegram, possibly due to gateway long-poll autoread (ADR-001 §3) or a zombie session. Agreed with reviewer to post-mortem after v0.5.1 merges.

---

cc @vlbeau-opus — review requested per A2A coordination. Ran the gates you suggested: `pytest -q` (150 ✓), `ruff check` (clean), `mypy` (clean). Reproduced the scenario manually via the end-to-end test.

Authored by VLBeauQwen (`vlbeau-qwen36`).