### PR TITLE
chore(docs): redact personal identifiers in LICENSE, pyproject, ADRs, plan, server.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Vincent Lefebvre
+Copyright (c) 2026 vlefebvre21
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/adr/ADR-001-multi-session-concurrency.md
+++ b/docs/adr/ADR-001-multi-session-concurrency.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-04-22
 - **Last updated:** 2026-04-22 (decision revised from hybrid B+C to A′ after review)
 - **Context window:** post v0.4.4
-- **Authors:** VLBeauClaudeOpus (architect), Vincent Lefebvre
+- **Authors:** VLBeauClaudeOpus (architect), vlefebvre21
 
 ## 1. Context
 
@@ -298,7 +298,7 @@ we introduce multi-host profiles or conversation-pinned routing.
 ## 6. References
 
 - Discovery conversation: 2026-04-22 Telegram chat, VLBeauClaudeOpus ↔
-  Vincent, re "root cause #9: cross-session interleave".
+  the user, re "root cause #9: cross-session interleave".
 - Bridge v0.4.4 release notes (webhook wake-up mechanism that enabled
   the concurrency to become routine rather than accidental).
 - Related Hermes topic: skills and memory are per-profile but have no

--- a/docs/adr/ADR-002-wake-intent-coupling.md
+++ b/docs/adr/ADR-002-wake-intent-coupling.md
@@ -3,7 +3,7 @@
 - **Status:** Proposed
 - **Date:** 2026-04-23
 - **Context window:** post v0.4.4
-- **Authors:** VLBeauClaudeOpus (architect), Vincent Lefebvre
+- **Authors:** VLBeauClaudeOpus (architect), vlefebvre21
 
 ## 1. Context
 
@@ -53,7 +53,7 @@ channel and are handled by the same code path.
 | 1 | **Task handoff dies as ack** | High | Implementer agent acks the task, never executes it. Discovered hours later by the requester. |
 | 2 | **Requester has no feedback loop** | High | The ack looks like progress. No "accepted but not started" signal, no timeout. |
 | 3 | **Silent scope reinterpretation** | Medium | Triage skill tends to condense messages into a reply — nuance and deliverables in the original brief get summarized away in the ack and lost. |
-| 4 | **Manual rescue required** | Medium | User (Vincent) had to notice the silence, check bus state, and re-prompt Qwen via Telegram the next morning. |
+| 4 | **Manual rescue required** | Medium | The user had to notice the silence, check bus state, and re-prompt Qwen via Telegram the next morning. |
 | 5 | **No way to express "do the thing" on the bus** | Medium | Any caller that wants an agent to *act* on a message, not just *respond* to it, has to reach out of band (Telegram, cron, direct MCP call). This defeats the point of A2A as a delegation mesh. |
 | 6 | **Cross-agent protocol ambiguity** | Low-Medium | Skill prompts across profiles diverge on how to handle "action-required" messages. Each agent has its own heuristic, none are guaranteed. |
 

--- a/docs/adr/ADR-003-worktree-isolation-and-git-identity.md
+++ b/docs/adr/ADR-003-worktree-isolation-and-git-identity.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted (reviewed 2026-04-23 by VLBeauClaudeOpus — LGTM + 3 nits inlined + 3 open questions resolved)
 - **Date:** 2026-04-23
 - **Context window:** post v0.4.4, parallel to v0.5-bridge-primitives branch
-- **Authors:** VLBeauQwen36 (drafter), VLBeauClaudeOpus (reviewer), Vincent Lefebvre
+- **Authors:** VLBeauQwen36 (drafter), VLBeauClaudeOpus (reviewer), vlefebvre21
 
 ## 1. Context
 
@@ -36,11 +36,11 @@ Compounding both issues, the shared working tree has a single
 `user.name` / `user.email` in `.git/config`:
 
 ```
-user.name=Vincent Lefebvre
-user.email=vlefebvre21@protonmail.com
+user.name=the user
+user.email=usermail@gmail.com
 ```
 
-All commits made by any agent (or by Vincent in person) land under the
+All commits made by any agent (or by the user in person) land under the
 same authorship. `git log --format='%an'` cannot distinguish agents, and
 `git reflog` cannot identify the author of a pointer mutation. Attribution
 today requires a cross-reference across three independent channels:
@@ -59,7 +59,7 @@ Two coupled problems to solve:
 
 - **P2 — Attribution.** Make `git log --format='%an %h %s'`
   self-sufficient for answering "which agent made this commit?" without
-  requiring A2A cross-reference. Additionally, make "Vincent committed
+  requiring A2A cross-reference. Additionally, make "the user committed
   this himself" visually distinct from "an agent committed this".
 
 Both problems already have workarounds (A2A diagnostic pings for P1;
@@ -112,7 +112,7 @@ Proposed identity mapping:
 | `vlbeau-qwen36`    | `VLBeauQwen`   | `qwen@vlbeau.local`     |
 | `vlbeau-glm51`     | `VLBeauGLM51`  | `glm51@vlbeau.local`    |
 | `vlbeau-deepseek`  | `VLBeauDeepSeek` | `deepseek@vlbeau.local` |
-| main checkout (Vincent) | `Vincent Lefebvre` | `vlefebvre21@protonmail.com` (unchanged) |
+| main checkout (the user) | `the user` | `usermail@gmail.com` |
 
 Each worktree has its own `HEAD`, `index`, and working copy. Branch
 pointers in `.git/refs/heads/` are shared across worktrees, but a
@@ -125,7 +125,7 @@ in worktree A does not affect the HEAD of worktree B.
   agents explicitly `git branch -f` the same ref. Everyday
   `checkout`/`rebase`/`reset` operations are isolated.
 - Solves P2: `git log --format='%an %h %s'` directly identifies the
-  agent. Commits by Vincent himself remain under his real identity, so
+  agent. Commits by the user himself remain under his real identity, so
   "agent vs human" attribution is also free.
 - No new tooling: `git worktree` is a standard git feature since 2.5.
 - WIP absorption race is largely eliminated — each agent sees its own
@@ -184,7 +184,7 @@ Rationale:
   boundary is the *profile*, not the *session*.
 - The CLA caveat is acceptable because VLBeau internal tooling is not
   upstreamed under these synthetic identities. If a patch needs to go
-  upstream, Vincent re-commits it from the main checkout under his own
+  upstream, the user re-commits it from the main checkout under his own
   identity, which is already the status quo.
 
 ## 5. Consequences
@@ -204,12 +204,12 @@ profile name and:
 ### 5.2 Agent memory
 
 Each agent's memory should record its **own** worktree path once, so
-that subsequent `cd /path` commands are correct without asking Vincent.
+that subsequent `cd /path` commands are correct without asking the user.
 Proposed memory entry:
 
 > `a2a-mcp-bridge worktree: /home/vince/projects/a2a-mcp-bridge-<profile>,
 > identity VLBeau<Profile> <<profile>@vlbeau.local>. NEVER operate on the
-> main checkout (/home/vince/projects/a2a-mcp-bridge) — that's Vincent's.`
+> main checkout (/home/vince/projects/a2a-mcp-bridge) — that's the user's.`
 
 ### 5.3 Shared-tree residual risk
 
@@ -233,13 +233,13 @@ Two residual cases remain even after Option 2:
   mutations only.
 - `github-pr-workflow` and `github-code-review`: ensure commit-signing
   and PR-authorship instructions reference the per-profile identity,
-  not `vlefebvre21@protonmail.com`.
+  not `usermail@gmail.com`.
 
 ### 5.5 CI / remote implications
 
 - GitHub and other remotes will display commits under
   `VLBeau<Profile>` with a fake `@vlbeau.local` email. For private
-  repos this is cosmetic; for public repos, squash-merge via Vincent's
+  repos this is cosmetic; for public repos, squash-merge via the user's
   main checkout re-attributes the final commit.
 - **Caveat on `@vlbeau.local`** — `.local` is reserved by RFC 6762
   (mDNS) for link-local name resolution. The address is intentionally
@@ -294,7 +294,7 @@ All three open questions from the draft have been resolved during the
    adopts the same pattern.
 
 3. **`vlbeau-main` profile handling** — the profile keeps its name;
-   its synthetic identity is `VLBeauOpus <opus@vlbeau.local>`. Vincent
+   its synthetic identity is `VLBeauOpus <opus@vlbeau.local>`. The user
    commits as himself from a shell **outside** Hermes (the main checkout
    retains his real `user.name`/`user.email`). This matches current
    practice and avoids renaming a widely-referenced profile.

--- a/docs/plans/2026-04-21-v0.1.md
+++ b/docs/plans/2026-04-21-v0.1.md
@@ -1154,7 +1154,7 @@ Add a "Getting started" section with a concrete Claude Desktop config snippet:
 
 ## Task 10: Push to GitHub + tag v0.1.0
 
-> **USER ACTION REQUIRED:** steps 1–2 need Vincent to authenticate `gh`.
+> **USER ACTION REQUIRED:** steps 1–2 need the user to authenticate `gh`.
 
 ```bash
 # Step 1: authenticate (interactive)
@@ -1193,7 +1193,7 @@ gh release create v0.1.0 --title "v0.1.0 — initial release" --notes-file CHANG
 | Tests pass locally, fail in CI | Python version mismatch | Check `requires-python` in `pyproject.toml` matches matrix |
 | `gh auth login` refuses | No browser in headless env | Use `gh auth login --with-token < token.txt` |
 
-**If something isn't covered here:** don't improvise silently. Post the exact error (command, stderr, traceback) and STOP. Vincent will review and adjust the plan.
+**If something isn't covered here:** don't improvise silently. Post the exact error (command, stderr, traceback) and STOP. The user will review and adjust the plan.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [{ name = "Vincent Lefebvre", email = "vlefebvre21@protonmail.com" }]
+authors = [{ name = "vlefebvre21", email = "usermail@gmail.com" }]
 requires-python = ">=3.11"
 keywords = ["mcp", "a2a", "ai-agents", "agent-to-agent", "llm", "inbox"]
 classifiers = [

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -123,7 +123,7 @@ class A2AMcp(FastMCP):
     2. The spec encourages servers to declare every capability they *might*
        use; this keeps our handshake honest.
 
-    Note (documented caveat for Vincent's setup):
+    Note (documented caveat for the user's setup):
     This does **not** solve the "client keeps talking to an old stdio server
     after a version upgrade" issue. An upgraded binary only runs after the
     parent process (Hermes gateway) restarts its stdio child. Emitting


### PR DESCRIPTION
## Redaction des identifiants personnels dans les fichiers du repo

Suite à ta relecture d'ADR-003, cette PR redacte le nom civil et le mail ProtonMail des fichiers du repo. L'objectif : que quiconque clone le repo ne tombe pas sur ces identifiants en lisant la doc ou le code.

### Changements

| Fichier | Avant | Après |
|---|---|---|
| `LICENSE` | `Copyright (c) 2026 Vincent Lefebvre` | `Copyright (c) 2026 vlefebvre21` |
| `pyproject.toml` authors | `"Vincent Lefebvre" / vlefebvre21@protonmail.com` | `"vlefebvre21" / usermail@gmail.com` |
| ADRs `Authors:` lines | `Vincent Lefebvre` | `vlefebvre21` |
| ADRs corps de texte | `Vincent` / `Vincent Lefebvre` | `the user` |
| ADR-003 exemples git config | `vlefebvre21@protonmail.com` | `usermail@gmail.com` |
| `docs/plans/2026-04-21-v0.1.md` | 2x `Vincent` | `the user` |
| `src/a2a_mcp_bridge/server.py:126` | `Vincent's setup` | `the user's setup` |

### Ce qui n'est PAS touché (volontairement)

- **URLs `github.com/vlefebvre21/...`** — c'est le nom du repo, changer casserait tout.
- **Historique git** — les commits existants gardent leur auteur original. Pas de `filter-repo` / force-push (destructif, et les anciens commits sont de toute façon sur GitHub via `vlefebvre21` qui reste visible).
- **`.venv/.../a2a_mcp_bridge-0.5.1.dist-info/`** — cache local d'un build antérieur, régénéré au prochain `pip install .`.

### Justifications des choix

- **`vlefebvre21`** (handle GitHub) plutôt que `lastname firstname` → déjà public, reconnu comme propriétaire du repo, pas de révélation supplémentaire.
- **`usermail@gmail.com`** plutôt que `xxx@vlbeau.local` → placeholder explicite, immédiatement identifiable comme faux.
- **`the user`** dans le corps des ADRs plutôt que le handle → lecture plus fluide, style neutre.

### Validation

```bash
# Après merge, vérifier qu'aucune occurrence ne reste :
grep -rn -iE "vincent|lefebvre|protonmail" \
  --include='*.md' --include='*.py' --include='*.yaml' \
  --include='*.toml' --include='LICENSE' --include='README*' \
  . | grep -v '.git/' | grep -v '.venv/'
# Seul résultat attendu : vlefebvre21 (handle volontaire)
```

### Commits futurs

Les commits de cette PR utilisent l'identité `VLBeauBot <vlbeau-bot@vlbeau.local>` pour marquer le passage à une identité de projet. Cohérent avec la direction d'ADR-003.

---

*Opened by `vlbeau-opus` after the user noticed the leak while re-reading ADR-003.*
