### PR TITLE
feat(scripts): bootstrap-agent-worktree.sh — implement ADR-003

### DIFF
--- a/scripts/bootstrap-agent-worktree.sh
+++ b/scripts/bootstrap-agent-worktree.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# bootstrap-agent-worktree.sh — Create a per-profile git worktree with a
+# distinct git identity for a Hermes agent.
+#
+# Implements ADR-003 (per-profile git worktrees and distinct git identities).
+# Scope: this repository only. For other repos, add a similar script per
+# repo until Hermes-level generalisation (ADR-003 §6 Q2).
+#
+# Usage: bootstrap-agent-worktree.sh [-b|--branch <name>] <profile>
+# Exit codes: 0 OK / 1 runtime error / 2 usage error.
+#
+set -euo pipefail
+
+# ── Profile identity table ──
+declare -A PROFILE_NAMES=(
+    [vlbeau-main]="VLBeauOpus"
+    [vlbeau-qwen36]="VLBeauQwen"
+    [vlbeau-glm51]="VLBeauGLM51"
+    [vlbeau-deepseek]="VLBeauDeepSeek"
+    [vlbeau-opus]="VLBeauOpusAlias"
+    [vlbeau-gemini]="VLBeauGemini"
+    [vlbeau-heavy]="VLBeauHeavy"
+    [vlbeau-mistral]="VLBeauMistral"
+    [vlbeau-magent]="VLBeauMagent"
+)
+
+declare -A PROFILE_EMAILS=(
+    [vlbeau-main]="opus@vlbeau.local"
+    [vlbeau-qwen36]="qwen@vlbeau.local"
+    [vlbeau-glm51]="glm51@vlbeau.local"
+    [vlbeau-deepseek]="deepseek@vlbeau.local"
+    [vlbeau-opus]="opus-alt@vlbeau.local"
+    [vlbeau-gemini]="gemini@vlbeau.local"
+    [vlbeau-heavy]="heavy@vlbeau.local"
+    [vlbeau-mistral]="mistral@vlbeau.local"
+    [vlbeau-magent]="magent@vlbeau.local"
+)
+
+# ── Usage ──
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] <profile>
+
+Create a git worktree for a Hermes agent profile.
+
+Arguments:
+  profile              One of: ${!PROFILE_NAMES[*]}
+
+Options:
+  -b, --branch <name>  Use <name> as the starting branch (default: main)
+  -h, --help           Show this help message and exit
+EOF
+}
+
+# ── Argument parsing ──
+profile=""
+branch="main"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -b|--branch)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --branch requires an argument" >&2
+                exit 2
+            fi
+            branch="$2"
+            shift 2
+            ;;
+        -*)
+            echo "ERROR: unknown option '$1'" >&2
+            exit 2
+            ;;
+        *)
+            profile="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$profile" ]]; then
+    usage >&2
+    exit 2
+fi
+
+# ── Validate profile ──
+if [[ -z "${PROFILE_NAMES[$profile]+x}" ]]; then
+    echo "ERROR: unknown profile '$profile'" >&2
+    exit 2
+fi
+
+user_name="${PROFILE_NAMES[$profile]}"
+user_email="${PROFILE_EMAILS[$profile]}"
+
+# ── Check we're inside a git repo ──
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ERROR: not inside a git repository" >&2
+    exit 1
+}
+
+repo_basename="$(basename "$repo_root")"
+repo_parent="$(dirname "$repo_root")"
+
+# ── Compute worktree path ──
+# Worktree lives as a sibling of the main checkout, with the profile short
+# name appended. Example: /home/vince/projects/a2a-mcp-bridge-qwen36.
+# Override via WORKTREE_PARENT env var (mainly for tests).
+profile_short="${profile#vlbeau-}"
+worktree_parent="${WORKTREE_PARENT:-$repo_parent}"
+worktree_path="${worktree_parent}/${repo_basename}-${profile_short}"
+
+# ── Check if path already exists ──
+if [[ -e "$worktree_path" ]]; then
+    if git worktree list --porcelain 2>/dev/null | grep -q "^worktree ${worktree_path}$"; then
+        echo "ERROR: worktree already exists at ${worktree_path}, use 'git worktree remove' first" >&2
+    else
+        echo "ERROR: ${worktree_path} exists but is not a git worktree" >&2
+    fi
+    exit 1
+fi
+
+# ── Check starting branch exists (local or remote) ──
+if ! git rev-parse --verify "refs/heads/${branch}" >/dev/null 2>&1 && \
+   ! git rev-parse --verify "refs/remotes/origin/${branch}" >/dev/null 2>&1; then
+    echo "ERROR: branch '${branch}' does not exist locally or on origin" >&2
+    exit 1
+fi
+
+# ── Create the worktree ──
+# Try checking out the branch directly first; if it's already checked out
+# elsewhere (e.g. in the source repo), create a -b tracking branch instead.
+if ! git worktree add "$worktree_path" "$branch" 2>/dev/null; then
+    wt_branch="worktrees/${profile}"
+    git worktree add -b "$wt_branch" "$worktree_path" "$branch"
+fi
+
+# ── Configure identity in the worktree ──
+git -C "$worktree_path" config user.name "$user_name"
+git -C "$worktree_path" config user.email "$user_email"
+
+echo "INFO: worktree created at ${worktree_path} (identity: ${user_name} <${user_email}>)"

--- a/tests/test_bootstrap_agent_worktree.bats
+++ b/tests/test_bootstrap_agent_worktree.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/bootstrap-agent-worktree.sh"
+
+setup() {
+    TEMP_REPO=$(mktemp -d)
+    cd "$TEMP_REPO"
+    git init -q -b main
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+    git commit -q --allow-empty -m "initial"
+    TEMP_REPO_BASENAME=$(basename "$TEMP_REPO")
+    # Use the temp repo's parent dir as worktree base so tests never
+    # write under /home/vince/projects/ even when WORKTREE_PARENT leaks
+    # from the environment.
+    TEMP_WORKTREE_PARENT=$(mktemp -d)
+    export WORKTREE_PARENT="$TEMP_WORKTREE_PARENT"
+    WORKTREE_BASE="${TEMP_WORKTREE_PARENT}/${TEMP_REPO_BASENAME}"
+}
+
+teardown() {
+    # Remove any worktree directories created during this test
+    if [[ -n "${WORKTREE_BASE:-}" ]]; then
+        for d in "${WORKTREE_BASE}"-*; do
+            [[ -d "$d" ]] && rm -rf "$d"
+        done
+    fi
+    # Remove temp worktree parent and temp repo
+    if [[ -n "${TEMP_WORKTREE_PARENT:-}" && -d "$TEMP_WORKTREE_PARENT" ]]; then
+        rm -rf "$TEMP_WORKTREE_PARENT"
+    fi
+    if [[ -d "${TEMP_REPO:-}" ]]; then
+        rm -rf "$TEMP_REPO"
+    fi
+    unset WORKTREE_PARENT
+}
+
+@test "test_help_flag: --help returns 0 and displays Usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "test_no_args: without argument returns 2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+}
+
+@test "test_unknown_profile: vlbeau-nonexistent returns 2 with 'unknown profile'" {
+    run "$SCRIPT" vlbeau-nonexistent
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown profile"* ]]
+}
+
+@test "test_known_profile_happy_path: vlbeau-qwen36 creates worktree with correct identity" {
+    run "$SCRIPT" vlbeau-qwen36
+    [ "$status" -eq 0 ]
+
+    expected_path="${WORKTREE_BASE}-qwen36"
+    [ -d "$expected_path" ]
+
+    # Verify worktree is tracked
+    run git worktree list
+    [[ "$output" == *"$expected_path"* ]]
+
+    # Verify identity
+    run git -C "$expected_path" config user.name
+    [ "$output" = "VLBeauQwen" ]
+
+    run git -C "$expected_path" config user.email
+    [ "$output" = "qwen@vlbeau.local" ]
+}
+
+@test "test_worktree_already_exists: calling with same profile again returns 1" {
+    profile="vlbeau-glm51"
+
+    # Create the worktree first
+    run "$SCRIPT" "$profile"
+    [ "$status" -eq 0 ]
+
+    # Try creating it again
+    run "$SCRIPT" "$profile"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"worktree already exists"* ]]
+}
+
+@test "test_nonexistent_branch: --branch does-not-exist returns 1" {
+    run "$SCRIPT" --branch does-not-exist vlbeau-mistral
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "test_outside_git_repo: running in /tmp returns 1" {
+    run env -C /tmp "$SCRIPT" vlbeau-qwen36
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not inside a git repository"* ]]
+}
+
+@test "test_dir_exists_not_worktree: directory exists but is not a git worktree, returns 1" {
+    expected_path="${WORKTREE_BASE}-heavy"
+
+    # Create a plain directory (not a git worktree)
+    mkdir -p "$expected_path"
+
+    run "$SCRIPT" vlbeau-heavy
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"exists but is not a git worktree"* ]]
+}


### PR DESCRIPTION
## Summary

Implements **ADR-003** (per-profile git worktrees + distinct git identities) by
adding a single setup script that any Hermes agent can run once to create an
isolated worktree with its own `user.name` / `user.email`.

- `scripts/bootstrap-agent-worktree.sh` (145 LOC) — Bash, `shellcheck` clean.
- `tests/test_bootstrap_agent_worktree.bats` (108 LOC) — 8 tests, all passing.

## Behaviour

Given a profile name (one of `vlbeau-{main,opus,glm51,qwen36,deepseek,gemini,heavy,mistral,magent}`),
the script:

1. Computes the worktree path at `<repo-parent>/<repo>-<profile-short>`
   (e.g. `/home/vince/projects/a2a-mcp-bridge-qwen36`).
2. Creates the worktree via `git worktree add` on the requested branch
   (default `main`, overridable via `-b|--branch <name>`).
3. Sets per-profile `user.name` / `user.email` from the canonical table
   (`VLBeau<Profile>` / `<profile>@vlbeau.local`) as specified in ADR-003 §3 Option 2.
4. Falls back to creating a new `worktrees/<profile>` branch when the source
   branch is already checked out in another worktree — so two agents can
   start from the same base without git collision.

## Edge cases covered

8 BATS tests, all passing:

- `--help` → exit 0 with Usage
- No args → exit 2
- Unknown profile → exit 2 with `unknown profile`
- Happy path: worktree created at correct path with correct identity
- Worktree already exists → exit 1 with clear message
- Directory exists but is not a worktree → exit 1 with distinct message
- `--branch does-not-exist` → exit 1
- Running outside a git repository → exit 1

Validation (local):

```
shellcheck scripts/bootstrap-agent-worktree.sh   # clean
bash -n scripts/bootstrap-agent-worktree.sh      # syntax OK
bats tests/test_bootstrap_agent_worktree.bats    # 8/8 ok
```

## Dogfood test

Script was used to create `/home/vince/projects/a2a-mcp-bridge-glm51` on
the author's machine. Worktree present, identity correctly set to
`VLBeauGLM51 <glm51@vlbeau.local>`, fallback branch `worktrees/vlbeau-glm51`
created automatically since the source branch was already checked out in the
main checkout.

## Scope note

ADR-003 §6 Q2: this script applies to **this repo only**. Hermes-level
generalisation is deferred until a second repo adopts the pattern. The script
header documents this.

A follow-up PR will update the affected skills referenced by ADR-003 §5.4
(`a2a-inbox-triage` Pitfall #8, `github-pr-workflow` identity references,
`github-code-review`). Those skills live in `~/.hermes/profiles/*/skills/`
rather than this repo, so they belong in a separate changeset.

## Test Plan

- [x] `shellcheck` clean
- [x] `bash -n` passes
- [x] 8/8 BATS tests pass
- [x] Manual dogfood test on the author's machine (worktree + identity verified)
- [ ] Reviewer to run the script once locally to double-check dogfood

## Refs

- `docs/adr/ADR-003-worktree-isolation-and-git-identity.md`
- Co-authored by `VLBeauQwen` (subagent delegation via Hermes GLM-5.1)
