### PR TITLE
feat(agent_send): intent field — implement ADR-002 (wake intent coupling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Theme** — ADR-002 wake-intent coupling (v0.6.0 milestone, γ scope).
+`agent_send` gains an optional `intent` field that lets senders annotate
+messages with their delivery semantics. v1 differentiates binary wake
+behaviour — `intent="fyi"` skips the webhook wake-up so a notification
+does not spawn a full LLM session on the recipient, which was the primary
+cost driver behind the 2026-04-23 Opus auto-wake burn.
+
+### Added
+- **`agent_send(intent=...)`** — optional string parameter on the MCP
+  tool. Accepted values: `triage` (default), `execute`, `review`,
+  `question`, `fyi`. The value is stored on the message row and echoed
+  in `agent_inbox` / `agent_inbox_peek` output. Unknown values downgrade
+  to `triage` with a WARNING log (forward-compat).
+- **`messages.intent TEXT NOT NULL DEFAULT 'triage'`** — new column on
+  the SQLite schema. Migrations auto-apply for pre-v0.6 databases via
+  `ALTER TABLE ... ADD COLUMN` inside a `BEGIN IMMEDIATE` transaction
+  (same pattern as v0.5 `sender_session_id`). Pre-existing rows inherit
+  `intent = 'triage'`.
+- **`a2a_mcp_bridge.intents`** — single-purpose module exporting
+  `VALID_INTENTS`, `DEFAULT_INTENT`, `NO_WAKE_INTENTS`, `normalize_intent`,
+  and `wakes`. The enum gate lives here; the SQL column is an opaque
+  string so a future v0.7 can extend the enum without a migration.
+- **`intent` key in `agent_inbox` / `agent_inbox_peek` output** — every
+  returned message dict now carries the intent value. Backward-compat
+  for pre-ADR-002 senders: their messages surface as `intent: "triage"`
+  via the column default.
+- **8 new tests in `tests/test_intent.py`** — normalise, wakes, default
+  wake triggers, `fyi` skips wake, unknown downgrade + warning,
+  migration from pre-v0.6 schema, inbox surface, empty-intent rejection.
+
+### Changed
+- **`Store.send_message` signature** — now accepts `intent: str = "triage"`
+  kwarg. Empty string / non-string raises `INTENT_INVALID`.
+- **`tool_agent_send` return dict** — adds `"intent"` key reflecting the
+  normalised intent actually stored. Callers can use this to confirm
+  downgrade happened.
+- **`tool_agent_send` wake policy** — wake is now skipped when the
+  normalised intent is in `NO_WAKE_INTENTS` (currently `{"fyi"}`). The
+  decision is made in the tool layer so `WebhookWaker.wake()` stays
+  semantics-agnostic. Log line: `wake skipped (intent=fyi) for target=…`
+  at INFO level.
+
+### Migration
+- Pre-v0.6 databases auto-upgrade on next `Store.init_schema()` call.
+  No action required from operators.
+- Callers that pin on the shape of the `agent_inbox` message dict need
+  to accept the additional `intent` key (`test_inbox_peek` and
+  `test_session_id` were updated to match).
+
+### Notes
+- The on-the-wire wake webhook payload is unchanged for v0.6 — `intent`
+  is stored and surfaced in the inbox, but not yet forwarded to the
+  recipient gateway's webhook. That is the v0.7 hook where per-intent
+  skill dispatch lands (see ADR-002 §4.1).
+- Specialised Hermes-side skills (`a2a-task-execution`,
+  `a2a-review-request`) are tracked separately per ADR-002 §4 items 5-8.
+  v0.6 ships only the bridge-side primitive.
+
 ## [0.5.1] - 2026-04-23
 
 **Theme** — signal cleanup bugfix for `agent_inbox` + `agent_subscribe` wake-up

--- a/docs/adr/ADR-002-wake-intent-coupling.md
+++ b/docs/adr/ADR-002-wake-intent-coupling.md
@@ -173,9 +173,11 @@ gateway / skills:
 
 **Bridge-side (this repo)**
 
-1. **`intent` field on `agent_send`** — optional string, enum-validated
+1. **`intent` field on `agent_send`** — optional string, validated
    against a fixed list (`triage`, `execute`, `review`, `question`,
-   `fyi`). Unknown values rejected with a clear error. Default: `triage`.
+   `fyi`). Unknown values are **downgraded to `triage` with a WARNING
+   log** rather than rejected, for forward-compat with future enum
+   extensions (see §4.1 below and §5.3 resolved Q5). Default: `triage`.
 2. **Intent propagation** — `intent` stored on the message row, echoed
    in `agent_inbox` / `agent_inbox_peek` output, and included in the
    wake-up webhook payload.

--- a/docs/adr/ADR-002-wake-intent-coupling.md
+++ b/docs/adr/ADR-002-wake-intent-coupling.md
@@ -1,9 +1,10 @@
 # ADR-002 — Wake-up intent is hardcoded to inbox triage
 
-- **Status:** Proposed
+- **Status:** Accepted — 2026-04-24 (Option A adopted with **Option γ v1 scope**: 5 intents declared, binary wake policy)
 - **Date:** 2026-04-23
+- **Last updated:** 2026-04-24 (decision accepted; v0.6 implementation landed)
 - **Context window:** post v0.4.4
-- **Authors:** VLBeauClaudeOpus (architect), vlefebvre21
+- **Authors:** VLBeauClaudeOpus (architect), VLBeauGLM51 (implementer), vlefebvre21
 
 ## 1. Context
 
@@ -207,6 +208,47 @@ at that point a queue-per-intent becomes a cleaner factoring than a
 field-per-intent. Until then, a single queue with an `intent` column is
 simpler.
 
+### 4.1 v1 scope — Option γ (landed in PR for v0.6.0)
+
+The production implementation on 2026-04-24 took the **γ variant** of
+Option A, narrowing the v1 surface for pragmatic reasons:
+
+| Aspect | v1 behaviour (landed) | v2+ deferred |
+|---|---|---|
+| Declared enum | 5 values — `triage`, `execute`, `review`, `question`, `fyi` | Same list; new values require an ADR amendment |
+| **Differentiated runtime behaviour** | **Binary — `fyi` skips the wake, all others wake** | Per-intent timeout, retry, session budget, dispatch to specialised Hermes skills |
+| Unknown values | Downgrade to `triage` + WARNING log (forward-compat — resolves §5.3 open Q5) | — |
+| Default when absent | `triage` (backward-compat — matches pre-ADR-002 behaviour exactly) | — |
+| Storage | `messages.intent TEXT NOT NULL DEFAULT 'triage'` (column is opaque-string; the enum lives in application code, not as SQL CHECK) | Could harden with a CHECK constraint once the enum is truly frozen |
+| Surface in `agent_inbox` | Yes, `intent` key in every returned message dict | — |
+| Specialised Hermes skills | **Not provided** — all wakes (regardless of intent) still hit `a2a-inbox-triage` on the recipient | `a2a-task-execution`, `a2a-review-request` (Hermes-side, tracked separately per §4 items 5-8) |
+
+Rationale for γ over the full Option A as written in §4:
+
+- **Zero skill-matrix dependency** — full Option A assumes 4-5 distinct
+  skills exist on every Hermes profile. They don't yet. Shipping the
+  bridge-side primitive without the Hermes-side skills means 4/5 values
+  would be silently degenerate (wake happens, but the `a2a-inbox-triage`
+  skill handles them all the same).
+- **Immediate budget win** — the observed cost-driver on 2026-04-23 was
+  2391 automatic wakes to Opus at ~$0.14 each. The single highest-ROI
+  change is enabling senders to mark a message as `fyi` and skip the
+  wake entirely; that alone validates the column, the enum, and the
+  inbox surface.
+- **Enum headroom preserved** — the column stores any string, and the
+  enum gate lives in `intents.py`. Extending the runtime differentiation
+  (e.g. `execute` → different skill + longer budget) is a one-commit
+  change with no migration.
+- **Forward-compat resolved** — §5.3 open Q5 ("unknown intent: reject
+  or downgrade?") is answered: downgrade to `triage` + log. Callers on
+  a newer bridge can send `execute`; older receivers downgrade it
+  invisibly to `triage` behaviour (which is the v1 default anyway).
+
+The on-the-wire JSON on the wake webhook payload is **unchanged** for
+v0.6 — the bridge currently does not yet surface `intent` to the gateway
+because no skill-dispatch logic consumes it there. That is the v0.7
+hook where Hermes-side routing lands.
+
 ## 5. Consequences
 
 ### 5.1 Positive
@@ -234,25 +276,32 @@ simpler.
   telling it to do arbitrary work). Receivers will need a small
   allowlist or downgrade policy.
 
-### 5.3 Open questions
+### 5.3 Open questions — **resolved 2026-04-24**
 
-- Where does the enum live — bridge repo, a shared schema package, or
-  documented in the README only? Leaning: **bridge repo** (it owns the
-  tool definitions).
-- Should `intent=execute` trigger a different wake-up retry policy
-  bridge-side? Leaning: **yes**, longer backoff and more attempts, on
-  the grounds that a missed task handoff is more costly than a missed
-  FYI.
-- Should the bridge expose a per-agent "accepted intents" field in
-  `agent_list` so callers can check before sending? Leaning: **v0.7**
-  — useful but not blocking. Ship the enum first, learn the mesh
-  behaviour, then codify capabilities.
-- How does `intent=execute` interact with ADR-001's gateway-mediated
-  inbox cache? Leaning: the cache stores the intent alongside the
-  message; the gateway consults the intent to decide which skill to
-  invoke when spawning the session. Both ADRs compose cleanly.
-- What does a receiver do with an unknown intent? Leaning: **downgrade
-  to triage and log a warning** rather than reject. Forward compat.
+- **Where does the enum live** — `src/a2a_mcp_bridge/intents.py`, a
+  single-purpose module exporting `VALID_INTENTS`, `DEFAULT_INTENT`,
+  `NO_WAKE_INTENTS`, `normalize_intent()`, and `wakes()`. Kept in the
+  bridge repo (option "bridge repo" from the draft) because the tool
+  definitions and the storage schema both live here. A shared schema
+  package can be extracted later if Hermes grows its own validators.
+- **Should `intent=execute` trigger a different wake-up retry policy
+  bridge-side?** — **Deferred to v0.7.** v1 (γ) only differentiates the
+  binary wake-or-skip axis. Adding per-intent retry is additive once the
+  base enum is in production.
+- **Should the bridge expose a per-agent "accepted intents" field in
+  `agent_list`?** — **Deferred to v0.7** (per the original lean). Not
+  blocking for v1.
+- **How does `intent=execute` interact with ADR-001's gateway-mediated
+  inbox cache?** — Unchanged: the cache stores the intent alongside the
+  message (the `messages.intent` column propagates into any cache
+  consumer). The gateway consults the intent when it has specialised
+  skills available; until then, the field is present but ignored by the
+  current `a2a-inbox-triage` prompt.
+- **What does a receiver do with an unknown intent?** — **Downgrade to
+  `triage` + log a WARNING.** Implemented in `intents.normalize_intent`,
+  consumed by `tool_agent_send`. Forward-compat: a v0.6 receiver can
+  process messages sent with `intent=execute` by a future v0.7 sender;
+  they just get triaged rather than executed.
 
 ## 6. References
 

--- a/src/a2a_mcp_bridge/intents.py
+++ b/src/a2a_mcp_bridge/intents.py
@@ -1,0 +1,76 @@
+"""Wake-up intent enum for ``agent_send`` (ADR-002).
+
+An intent annotates a message with its delivery semantics. Current v0.6 scope
+(Option γ — 5 values declared, binary wake behaviour):
+
+* ``triage`` (default) — "read, reply if relevant, done". Current behaviour.
+* ``execute`` — task handoff; recipient continues autonomously until done.
+* ``review`` — structured review request (LGTM / REQUEST_CHANGES).
+* ``question`` — needs an answer, not a task.
+* ``fyi`` — heads up, no action required, no reply expected. **Wake skipped.**
+
+The bridge itself enforces only the wake policy (skip wake for no-wake
+intents). Semantic dispatch to specialised skills (``a2a-task-execution``,
+``a2a-review-request``) is a Hermes-side concern tracked separately — see
+ADR-002 §4 Hermes-side work.
+"""
+
+from __future__ import annotations
+
+# All recognised intent values.
+# Keep alphabetised for diff stability; add new values here first when
+# extending the enum, then wire up behaviour below.
+VALID_INTENTS: frozenset[str] = frozenset(
+    {"execute", "fyi", "question", "review", "triage"}
+)
+
+# Default intent applied when the caller omits the field or passes None.
+# Must match the pre-ADR-002 behaviour (wake-up triggers the inbox-triage
+# skill on the recipient) so existing callers are unaffected.
+DEFAULT_INTENT: str = "triage"
+
+# Intents that DO NOT trigger a webhook wake-up. The message is still
+# persisted and still touches the signal file (so ``agent_subscribe`` and
+# the next natural ``agent_inbox`` pick it up), but no HTTP wake is POSTed
+# to the recipient's gateway — the whole point of the ``fyi`` intent is to
+# avoid spawning an expensive LLM session for a notification nobody needs
+# to action.
+NO_WAKE_INTENTS: frozenset[str] = frozenset({"fyi"})
+
+
+def normalize_intent(raw: str | None) -> tuple[str, bool]:
+    """Normalise a caller-supplied ``intent`` value.
+
+    Args:
+        raw: the caller-supplied intent string, or ``None``.
+
+    Returns:
+        ``(normalised, downgraded)`` where:
+          * ``normalised`` is the value to store (always in :data:`VALID_INTENTS`);
+          * ``downgraded`` is ``True`` when the caller passed an unknown value
+            that was silently downgraded to :data:`DEFAULT_INTENT`. Callers can
+            use this flag to log a WARNING without re-parsing.
+
+    Rules:
+        * ``None`` → (``DEFAULT_INTENT``, ``False``). No warning — absence is
+          legitimate backward-compat behaviour.
+        * A value in :data:`VALID_INTENTS` → (value, ``False``). Pass-through.
+        * Anything else → (``DEFAULT_INTENT``, ``True``). Forward-compat
+          downgrade as prescribed by ADR-002 §5.3 ("unknown intent →
+          downgrade to triage and log a warning rather than reject").
+    """
+    if raw is None:
+        return DEFAULT_INTENT, False
+    if raw in VALID_INTENTS:
+        return raw, False
+    return DEFAULT_INTENT, True
+
+
+def wakes(intent: str) -> bool:
+    """Return ``True`` if ``intent`` triggers a webhook wake-up.
+
+    Assumes ``intent`` has been normalised (i.e. is in :data:`VALID_INTENTS`).
+    For defensive callers: an unrecognised value is treated as wake-triggering,
+    matching the forward-compat downgrade policy.
+    """
+    return intent not in NO_WAKE_INTENTS

--- a/src/a2a_mcp_bridge/intents.py
+++ b/src/a2a_mcp_bridge/intents.py
@@ -1,7 +1,7 @@
 """Wake-up intent enum for ``agent_send`` (ADR-002).
 
 An intent annotates a message with its delivery semantics. Current v0.6 scope
-(Option γ — 5 values declared, binary wake behaviour):
+(Option gamma -- 5 values declared, binary wake behaviour):
 
 * ``triage`` (default) — "read, reply if relevant, done". Current behaviour.
 * ``execute`` — task handoff; recipient continues autonomously until done.

--- a/src/a2a_mcp_bridge/models.py
+++ b/src/a2a_mcp_bridge/models.py
@@ -37,6 +37,7 @@ class Message(BaseModel):
     created_at: datetime
     read_at: datetime | None = None
     sender_session_id: str | None = None
+    intent: str = "triage"
 
     @field_validator("sender_id", "recipient_id")
     @classmethod

--- a/src/a2a_mcp_bridge/schema.sql
+++ b/src/a2a_mcp_bridge/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS messages (
     created_at TEXT NOT NULL,
     read_at TEXT,
     sender_session_id TEXT,
+    intent TEXT NOT NULL DEFAULT 'triage',
     FOREIGN KEY (sender_id) REFERENCES agents(id),
     FOREIGN KEY (recipient_id) REFERENCES agents(id)
 );

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -173,6 +173,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         target: str,
         message: str,
         metadata: dict[str, Any] | None = None,
+        intent: str | None = None,
     ) -> dict[str, Any]:
         """Send a message to another agent on the bus.
 
@@ -190,9 +191,19 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
                 A reserved key ``session_id`` (string, ≤ 128 bytes UTF-8) is
                 hoisted into a dedicated column and surfaced in the inbox
                 payload — see ADR-001 §4 #2.
+            intent: optional wake-up intent (ADR-002). One of
+                ``triage`` (default), ``execute``, ``review``, ``question``,
+                ``fyi``. Controls the recipient wake-up behaviour:
+                  * ``fyi`` — no webhook wake-up; recipient reads the message
+                    at the next natural inbox poll. Use for notifications
+                    that do not require an immediate reply.
+                  * all others — standard webhook wake-up (current behaviour).
+                Unknown values downgrade to ``triage`` with a WARNING log.
 
         Returns:
-            {"message_id", "sent_at", "recipient"} on success, or {"error": {"code", "message"}}.
+            ``{"message_id", "sent_at", "recipient", "intent"}`` on success
+            (``intent`` is the normalised value actually stored), or
+            ``{"error": {"code", "message"}}``.
             Validation errors on the reserved session_id key:
             ``SESSION_ID_INVALID`` (not a string) or ``SESSION_ID_TOO_LARGE``.
 
@@ -201,9 +212,12 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
 
         Side effect (v0.4.4+): if `A2A_WAKE_REGISTRY` points at a valid v0.4.4
         webhook registry, fires an HMAC-signed wake-up POST to the recipient's
-        local gateway endpoint.
+        local gateway endpoint. SKIPPED for ``intent=fyi`` (ADR-002).
         """
-        return tool_agent_send(store, agent_id, target, message, metadata, signal_dir, waker)
+        return tool_agent_send(
+            store, agent_id, target, message, metadata, signal_dir, waker,
+            intent=intent,
+        )
 
     @mcp.tool()
     def agent_inbox(

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -284,7 +284,7 @@ class Store:
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
                 sender_session_id=r["sender_session_id"],
-                intent=r["intent"] if "intent" in r.keys() else "triage",
+                intent=r["intent"],
             )
             for r in rows
         ]
@@ -353,7 +353,7 @@ class Store:
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
                 sender_session_id=r["sender_session_id"],
-                intent=r["intent"] if "intent" in r.keys() else "triage",
+                intent=r["intent"],
             )
             for r in rows
         ]

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -44,7 +44,8 @@ class Store:
         branches naturally. For pre-v0.5 DBs on disk we need to add columns
         introduced later without dropping data.
 
-        Each migration step:
+        Each migration step is delegated to :meth:`_add_column_if_missing`,
+        which:
           * wraps its work in ``BEGIN IMMEDIATE`` / ``COMMIT`` so a concurrent
             writer (e.g. another Hermes profile spinning up) cannot interleave
             between the ``PRAGMA table_info`` probe and the ``ALTER TABLE``;
@@ -60,58 +61,71 @@ class Store:
           intent coupling, see ADR-002).
         """
         # v0.5 — messages.sender_session_id
-        existing_cols = {
-            row["name"]
-            for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
-        }
-        if "sender_session_id" not in existing_cols:
-            self._conn.execute("BEGIN IMMEDIATE")
-            try:
-                # Re-check inside the transaction in case a concurrent writer
-                # raced us between the probe above and here.
-                cols = {
-                    row["name"]
-                    for row in self._conn.execute(
-                        "PRAGMA table_info(messages)"
-                    ).fetchall()
-                }
-                if "sender_session_id" not in cols:
-                    self._conn.execute(
-                        "ALTER TABLE messages ADD COLUMN sender_session_id TEXT"
-                    )
-                self._conn.execute("COMMIT")
-            except Exception:
-                self._conn.execute("ROLLBACK")
-                raise
+        self._add_column_if_missing(
+            table="messages",
+            column="sender_session_id",
+            column_type="TEXT",
+        )
+        # v0.6 — messages.intent (ADR-002). NOT NULL + DEFAULT 'triage' so
+        # SQLite back-fills existing rows (every pre-ADR-002 message is
+        # semantically a triage handoff, preserving backward-compat).
+        self._add_column_if_missing(
+            table="messages",
+            column="intent",
+            column_type="TEXT NOT NULL DEFAULT 'triage'",
+        )
 
-        # v0.6 — messages.intent (ADR-002)
-        # Re-read after any v0.5 migration so the probe reflects the latest
-        # schema without another round-trip.
+    def _add_column_if_missing(
+        self,
+        *,
+        table: str,
+        column: str,
+        column_type: str,
+    ) -> None:
+        """Idempotently add ``column`` to ``table`` with the given type clause.
+
+        Safe to call repeatedly: if the column already exists (fresh DB
+        created from the current ``CREATE TABLE IF NOT EXISTS`` schema, or
+        prior migration run), this is a no-op. The probe-then-ALTER race
+        against a concurrent writer is closed by a ``BEGIN IMMEDIATE``
+        transaction around the second probe + the ALTER itself.
+
+        Args:
+            table: target table name (unvalidated — caller-controlled).
+            column: column name to add.
+            column_type: full SQL type clause minus ``ADD COLUMN``, e.g.
+                ``TEXT`` or ``TEXT NOT NULL DEFAULT 'triage'``. NOT NULL +
+                DEFAULT is required to back-fill existing rows; a bare
+                ``TEXT`` produces NULL in old rows.
+        """
         existing_cols = {
             row["name"]
-            for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+            for row in self._conn.execute(
+                f"PRAGMA table_info({table})"
+            ).fetchall()
         }
-        if "intent" not in existing_cols:
-            self._conn.execute("BEGIN IMMEDIATE")
-            try:
-                cols = {
-                    row["name"]
-                    for row in self._conn.execute(
-                        "PRAGMA table_info(messages)"
-                    ).fetchall()
-                }
-                if "intent" not in cols:
-                    # NOT NULL + DEFAULT 'triage': SQLite back-fills existing
-                    # rows with the default, preserving backward-compat (every
-                    # pre-ADR-002 message is semantically a triage handoff).
-                    self._conn.execute(
-                        "ALTER TABLE messages "
-                        "ADD COLUMN intent TEXT NOT NULL DEFAULT 'triage'"
-                    )
-                self._conn.execute("COMMIT")
-            except Exception:
-                self._conn.execute("ROLLBACK")
-                raise
+        if column in existing_cols:
+            return
+
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Re-check inside the transaction in case a concurrent writer
+            # (another Hermes profile starting up) raced us between the probe
+            # above and here.
+            cols = {
+                row["name"]
+                for row in self._conn.execute(
+                    f"PRAGMA table_info({table})"
+                ).fetchall()
+            }
+            if column not in cols:
+                self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {column} {column_type}"
+                )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
 
     def close(self) -> None:
         self._conn.close()

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from .intents import DEFAULT_INTENT
 from .models import (
     MAX_BODY_BYTES,
     MAX_METADATA_BYTES,
@@ -55,6 +56,8 @@ class Store:
 
         * v0.5 — ``messages.sender_session_id TEXT NULL`` (A2A session
           correlation, see ADR-001).
+        * v0.6 — ``messages.intent TEXT NOT NULL DEFAULT 'triage'`` (wake
+          intent coupling, see ADR-002).
         """
         # v0.5 — messages.sender_session_id
         existing_cols = {
@@ -75,6 +78,35 @@ class Store:
                 if "sender_session_id" not in cols:
                     self._conn.execute(
                         "ALTER TABLE messages ADD COLUMN sender_session_id TEXT"
+                    )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+        # v0.6 — messages.intent (ADR-002)
+        # Re-read after any v0.5 migration so the probe reflects the latest
+        # schema without another round-trip.
+        existing_cols = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "intent" not in existing_cols:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                cols = {
+                    row["name"]
+                    for row in self._conn.execute(
+                        "PRAGMA table_info(messages)"
+                    ).fetchall()
+                }
+                if "intent" not in cols:
+                    # NOT NULL + DEFAULT 'triage': SQLite back-fills existing
+                    # rows with the default, preserving backward-compat (every
+                    # pre-ADR-002 message is semantically a triage handoff).
+                    self._conn.execute(
+                        "ALTER TABLE messages "
+                        "ADD COLUMN intent TEXT NOT NULL DEFAULT 'triage'"
                     )
                 self._conn.execute("COMMIT")
             except Exception:
@@ -127,11 +159,21 @@ class Store:
         recipient: str,
         body: str,
         metadata: dict[str, Any] | None = None,
+        intent: str = DEFAULT_INTENT,
     ) -> SendResult:
         if sender == recipient:
             raise ValueError("TARGET_SELF: cannot send to self")
         if len(body.encode("utf-8")) > MAX_BODY_BYTES:
             raise ValueError(f"MESSAGE_TOO_LARGE: body exceeds {MAX_BODY_BYTES} bytes")
+
+        # ``intent`` is expected to already be normalised by the caller (the
+        # tool layer in ``tools.py`` runs ``normalize_intent`` and logs the
+        # downgrade warning). We defensively accept any value here but write
+        # whatever string was provided — the NOT NULL constraint will reject
+        # None, and the column accepts opaque strings so a future caller can
+        # extend the enum without a schema change.
+        if not isinstance(intent, str) or not intent:
+            raise ValueError("INTENT_INVALID: intent must be a non-empty string")
 
         # Extract and validate the optional session_id convention (ADR-001 §4 #2).
         # The session_id travels inside the caller-supplied ``metadata`` dict so
@@ -171,10 +213,10 @@ class Store:
         now = datetime.now(UTC)
         self._conn.execute(
             """
-            INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at, sender_session_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at, sender_session_id, intent)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (message_id, sender, recipient, body, metadata_json, now.isoformat(), session_id),
+            (message_id, sender, recipient, body, metadata_json, now.isoformat(), session_id, intent),
         )
         return SendResult(message_id=message_id, sent_at=now, recipient=recipient)
 
@@ -191,7 +233,7 @@ class Store:
             try:
                 rows = self._conn.execute(
                     """
-                    SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
+                    SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id, intent
                     FROM messages
                     WHERE recipient_id = ? AND read_at IS NULL
                     ORDER BY created_at ASC
@@ -209,7 +251,7 @@ class Store:
                     # Re-read to include read_at values in returned objects
                     rows = self._conn.execute(
                         f"""
-                        SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
+                        SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id, intent
                         FROM messages
                         WHERE id IN ({placeholders})
                         ORDER BY created_at ASC
@@ -223,7 +265,7 @@ class Store:
         else:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id, intent
                 FROM messages
                 WHERE recipient_id = ?
                 ORDER BY created_at DESC
@@ -242,6 +284,7 @@ class Store:
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
                 sender_session_id=r["sender_session_id"],
+                intent=r["intent"] if "intent" in r.keys() else "triage",
             )
             for r in rows
         ]
@@ -280,7 +323,7 @@ class Store:
         if since_ts is None:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id, intent
                 FROM messages
                 WHERE recipient_id = ?
                 ORDER BY created_at DESC
@@ -291,7 +334,7 @@ class Store:
         else:
             rows = self._conn.execute(
                 """
-                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id
+                SELECT id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id, intent
                 FROM messages
                 WHERE recipient_id = ? AND created_at >= ?
                 ORDER BY created_at ASC
@@ -310,6 +353,7 @@ class Store:
                 created_at=datetime.fromisoformat(r["created_at"]),
                 read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
                 sender_session_id=r["sender_session_id"],
+                intent=r["intent"] if "intent" in r.keys() else "triage",
             )
             for r in rows
         ]

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import Any
 
+from .intents import DEFAULT_INTENT, normalize_intent, wakes
 from .logging_ext import hash_body, log_event
 from .signals import SignalDir
 from .store import Store
@@ -26,6 +27,7 @@ def tool_agent_send(
     metadata: dict[str, Any] | None = None,
     signal_dir: SignalDir | None = None,
     waker: WebhookWaker | None = None,
+    intent: str | None = None,
 ) -> dict[str, Any]:
     """Send a message from ``caller_id`` to ``target``.
 
@@ -39,6 +41,16 @@ def tool_agent_send(
 
     Both hooks are best-effort: failures are logged but never propagated — the
     authoritative record is always the SQLite store.
+
+    ADR-002 wake-intent coupling (v0.6+):
+      The optional ``intent`` parameter annotates the message with its
+      delivery semantics (``triage``, ``execute``, ``review``, ``question``,
+      ``fyi``). Intents in ``NO_WAKE_INTENTS`` (currently just ``fyi``)
+      persist the message and touch the signal file but **skip** the webhook
+      wake-up — the recipient will see the message at the next natural
+      ``agent_inbox`` call instead of spawning a fresh LLM session. Unknown
+      values are downgraded to ``triage`` with a WARNING log, preserving
+      forward-compat as prescribed by ADR-002 §5.3.
     """
     start = time.perf_counter()
     session_id: str | None = None
@@ -47,6 +59,20 @@ def tool_agent_send(
         if isinstance(sid, str):
             session_id = sid
 
+    # Normalise intent (absent → default, unknown → downgrade + warn).
+    normalized_intent, downgraded = normalize_intent(intent)
+    if downgraded:
+        log_event(
+            logger,
+            event="tool.agent_send.intent_downgraded",
+            agent_id=caller_id,
+            level=logging.WARNING,
+            session_id=session_id,
+            target=target,
+            requested_intent=intent,
+            effective_intent=normalized_intent,
+        )
+
     store.upsert_agent(caller_id)
     try:
         result = store.send_message(
@@ -54,6 +80,7 @@ def tool_agent_send(
             recipient=target,
             body=message,
             metadata=metadata,
+            intent=normalized_intent,
         )
     except ValueError as e:
         code, _, msg = str(e).partition(":")
@@ -74,11 +101,23 @@ def tool_agent_send(
     if signal_dir is not None:
         signal_dir.notify(target)
 
+    # Wake policy (ADR-002): skip the webhook for no-wake intents (``fyi``).
+    # The message is still persisted and still signals agent_subscribe; we
+    # just don't spawn a fresh LLM session for notifications that do not
+    # require immediate action.
     if waker is not None:
-        try:
-            waker.wake(target, sender_id=caller_id)
-        except Exception as exc:  # pragma: no cover - waker must swallow, defensive
-            logger.warning("waker raised for %s: %s", target, exc)
+        if wakes(normalized_intent):
+            try:
+                waker.wake(target, sender_id=caller_id)
+            except Exception as exc:  # pragma: no cover - waker must swallow, defensive
+                logger.warning("waker raised for %s: %s", target, exc)
+        else:
+            logger.info(
+                "wake skipped (intent=%s) for target=%s from sender=%s",
+                normalized_intent,
+                target,
+                caller_id,
+            )
 
     log_event(
         logger,
@@ -88,12 +127,14 @@ def tool_agent_send(
         target=target,
         message_id=result.message_id,
         body_hash=hash_body(message),
+        intent=normalized_intent,
         duration_ms=round((time.perf_counter() - start) * 1000, 2),
     )
     return {
         "message_id": result.message_id,
         "sent_at": result.sent_at.isoformat(),
         "recipient": result.recipient,
+        "intent": normalized_intent,
     }
 
 
@@ -278,4 +319,5 @@ def _serialize_message(m: Any) -> dict[str, Any]:
         "sent_at": m.created_at.isoformat(),
         "read_at": m.read_at.isoformat() if m.read_at else None,
         "sender_session_id": m.sender_session_id,
+        "intent": getattr(m, "intent", DEFAULT_INTENT),
     }

--- a/tests/test_inbox_peek.py
+++ b/tests/test_inbox_peek.py
@@ -154,7 +154,8 @@ class TestAgentInboxPeekPayloadShape:
         peek = tool_agent_inbox_peek(store, "bob")
         assert len(peek["messages"]) == 1
         m = peek["messages"][0]
-        # Same keys as agent_inbox's serialisation (now includes sender_session_id)
+        # Same keys as agent_inbox's serialisation (now includes
+        # sender_session_id + intent — ADR-001/002).
         assert set(m.keys()) == {
             "message_id",
             "sender",
@@ -163,6 +164,7 @@ class TestAgentInboxPeekPayloadShape:
             "sent_at",
             "read_at",
             "sender_session_id",
+            "intent",
         }
         assert m["sender"] == "alice"
         assert m["metadata"] == {"topic": "ping"}

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -5,11 +5,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from a2a_mcp_bridge.intents import normalize_intent, wakes, VALID_INTENTS, DEFAULT_INTENT
+from a2a_mcp_bridge.intents import normalize_intent, wakes
 from a2a_mcp_bridge.store import Store
-from a2a_mcp_bridge.tools import tool_agent_send, tool_agent_inbox
+from a2a_mcp_bridge.tools import tool_agent_inbox, tool_agent_send
 from a2a_mcp_bridge.wake import WebhookWaker
-
 
 # ---------------------------------------------------------------------------
 # Test 1: normalize_intent behaviour

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,208 @@
+"""Tests for ADR-002 intent field implementation."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from a2a_mcp_bridge.intents import normalize_intent, wakes, VALID_INTENTS, DEFAULT_INTENT
+from a2a_mcp_bridge.store import Store
+from a2a_mcp_bridge.tools import tool_agent_send, tool_agent_inbox
+from a2a_mcp_bridge.wake import WebhookWaker
+
+
+# ---------------------------------------------------------------------------
+# Test 1: normalize_intent behaviour
+# ---------------------------------------------------------------------------
+
+def test_normalize_intent_none_returns_default() -> None:
+    assert normalize_intent(None) == ("triage", False)
+    assert normalize_intent("fyi") == ("fyi", False)
+    assert normalize_intent("execute") == ("execute", False)
+    assert normalize_intent("bogus-xyz") == ("triage", True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: wakes helper
+# ---------------------------------------------------------------------------
+
+def test_wakes_helper() -> None:
+    assert wakes("triage") is True
+    assert wakes("execute") is True
+    assert wakes("review") is True
+    assert wakes("question") is True
+    assert wakes("fyi") is False
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture for tool-level tests (#3, #4, #5)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _tool_store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.sqlite"))
+    s.init_schema()
+    s.upsert_agent("sender")
+    s.upsert_agent("receiver")
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Test 3: default intent triggers wake
+# ---------------------------------------------------------------------------
+
+def test_send_default_intent_triggers_wake(_tool_store: Store) -> None:
+    waker = MagicMock(spec=WebhookWaker)
+
+    result = tool_agent_send(
+        _tool_store, "sender", "receiver", "hello", waker=waker
+    )
+
+    assert result["intent"] == "triage"
+    waker.wake.assert_called_once_with("receiver", sender_id="sender")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: fyi intent skips wake
+# ---------------------------------------------------------------------------
+
+def test_send_intent_fyi_skips_wake(_tool_store: Store) -> None:
+    waker = MagicMock(spec=WebhookWaker)
+
+    result = tool_agent_send(
+        _tool_store, "sender", "receiver", "hello", waker=waker, intent="fyi"
+    )
+
+    assert result["intent"] == "fyi"
+    waker.wake.assert_not_called()
+    assert "message_id" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: unknown intent downgrades to triage with WARNING log
+# ---------------------------------------------------------------------------
+
+def test_send_unknown_intent_downgrades_to_triage_and_logs_warning(
+    _tool_store: Store, caplog: pytest.LogCaptureFixture
+) -> None:
+    waker = MagicMock(spec=WebhookWaker)
+
+    result = tool_agent_send(
+        _tool_store, "sender", "receiver", "hello",
+        waker=waker, intent="bogus-xyz"
+    )
+
+    assert result["intent"] == "triage"
+    waker.wake.assert_called_once()
+    assert any("intent_downgraded" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: migration adds intent column to existing DB
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_intent_column_to_existing_db(tmp_path: Path) -> None:
+    import sqlite3
+
+    db_path = tmp_path / "old_bus.sqlite"
+
+    # Create OLD schema (without messages.intent column)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY, sender_id TEXT NOT NULL, recipient_id TEXT NOT NULL,
+            body TEXT NOT NULL, metadata TEXT, created_at TEXT NOT NULL, read_at TEXT,
+            sender_session_id TEXT
+        );
+        CREATE TABLE agents (
+            id TEXT PRIMARY KEY, first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL,
+            metadata TEXT
+        );
+    """)
+    # Insert some dummy rows
+    conn.execute(
+        """
+        INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id)
+        VALUES ('m1', 'a', 'b', 'old msg1', NULL, '2024-01-01T00:00:00+00:00', NULL, NULL);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (id, sender_id, recipient_id, body, metadata, created_at, read_at, sender_session_id)
+        VALUES ('m2', 'a', 'b', 'old msg2', NULL, '2024-01-02T00:00:00+00:00', NULL, NULL);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (id, first_seen_at, last_seen_at, metadata)
+        VALUES ('a', '2024-01-01T00:00:00+00:00', '2024-01-01T00:00:00+00:00', NULL);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agents (id, first_seen_at, last_seen_at, metadata)
+        VALUES ('b', '2024-01-01T00:00:00+00:00', '2024-01-01T00:00:00+00:00', NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # Open with Store — triggers migration
+    store = Store(str(db_path))
+    store.init_schema()
+
+    # Verify intent column exists (PRAGMA table_info returns tuples: (cid, name, type, notnull, dflt_value, pk))
+    pragma_cols = {row[1] for row in store._conn.execute("PRAGMA table_info(messages)").fetchall()}
+    assert "intent" in pragma_cols
+
+    # Verify old rows have intent = 'triage'
+    rows = store._conn.execute("SELECT id, intent FROM messages").fetchall()
+    assert all(r[1] == "triage" for r in rows)
+
+    # Verify new send persists custom intent
+    store.send_message("a", "b", "new msg", intent="fyi")
+    new_row = store._conn.execute(
+        "SELECT intent FROM messages WHERE id = (SELECT id FROM messages ORDER BY created_at DESC LIMIT 1)"
+    ).fetchone()
+    assert new_row[0] == "fyi"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: agent_inbox returns intent field
+# ---------------------------------------------------------------------------
+
+def test_agent_inbox_returns_intent_field(tmp_path: Path) -> None:
+    store = Store(str(tmp_path / "bus.sqlite"))
+    store.init_schema()
+    store.upsert_agent("sender")
+    store.upsert_agent("receiver")
+
+    store.send_message("sender", "receiver", "msg1", intent="triage")
+    store.send_message("sender", "receiver", "msg2", intent="fyi")
+
+    inbox = tool_agent_inbox(store, "receiver", limit=10, unread_only=False)
+
+    assert len(inbox["messages"]) == 2
+    # The inbox returns DESC by created_at, so msg2 is first
+    intents = {m["intent"] for m in inbox["messages"]}
+    assert intents == {"triage", "fyi"}
+    # Verify each message dict actually has "intent" key
+    for m in inbox["messages"]:
+        assert "intent" in m
+
+
+# ---------------------------------------------------------------------------
+# Test 8: store enforces valid intent (empty / None rejected)
+# ---------------------------------------------------------------------------
+
+def test_store_send_message_rejects_empty_intent(tmp_path: Path) -> None:
+    store = Store(str(tmp_path / "bus.sqlite"))
+    store.init_schema()
+    store.upsert_agent("sender")
+    store.upsert_agent("receiver")
+
+    with pytest.raises(ValueError, match="INTENT_INVALID"):
+        store.send_message("sender", "receiver", "body", intent="")
+
+    with pytest.raises(ValueError, match="INTENT_INVALID"):
+        store.send_message("sender", "receiver", "body", intent=None)  # type: ignore[arg-type]

--- a/tests/test_session_id.py
+++ b/tests/test_session_id.py
@@ -177,7 +177,12 @@ class TestSessionIdBackwardCompat:
     def test_existing_inbox_shape_unchanged_without_session_id(
         self, store: Store
     ) -> None:
-        """Pre-v0.5 callers see ``sender_session_id: None`` and that's it."""
+        """Pre-v0.5 callers see ``sender_session_id: None`` + ``intent: 'triage'``.
+
+        Shape updated for ADR-002: ``intent`` is now part of the canonical
+        inbox dict. Omitted caller ``intent`` defaults to ``'triage'``, so
+        backward-compat senders still see a stable (if enriched) shape.
+        """
         _register(store, "alice", "bob")
         tool_agent_send(store, "alice", target="bob", message="hi")
 
@@ -191,6 +196,8 @@ class TestSessionIdBackwardCompat:
             "sent_at",
             "read_at",
             "sender_session_id",
+            "intent",
         }
         assert set(m.keys()) == expected_keys
         assert m["sender_session_id"] is None
+        assert m["intent"] == "triage"


### PR DESCRIPTION
## Summary

Implements **ADR-002** (wake-intent coupling) with the v1 **γ scope**:
5 intents declared, binary wake policy.

Senders can now annotate `agent_send` calls with an `intent` string.
Messages with `intent="fyi"` persist to the bus and touch the signal
file like any other message, but **do not trigger a webhook wake-up** —
no LLM session spawned on the recipient. This is the direct budget
control lever missing from v0.5: the root cause of the 2026-04-23 Opus
auto-wake burn (2391 requests / $326 in one UTC day) was that **every**
A2A message woke up Opus regardless of whether a reply was actually
expected.

## What's in the diff

### New
- `src/a2a_mcp_bridge/intents.py` — single-purpose module exporting
  `VALID_INTENTS`, `DEFAULT_INTENT`, `NO_WAKE_INTENTS`, `normalize_intent`,
  `wakes`. The enum gate lives here.
- `tests/test_intent.py` — 8 tests covering normalise, wakes, default
  wake path, fyi skip, unknown downgrade, migration, inbox surface,
  empty-intent rejection.

### Changed
- `src/a2a_mcp_bridge/schema.sql` — added
  `intent TEXT NOT NULL DEFAULT 'triage'` on `messages`.
- `src/a2a_mcp_bridge/store.py` — auto-migration branch for the new
  column (same `BEGIN IMMEDIATE` + `PRAGMA table_info` pattern as the
  v0.5 `sender_session_id` migration). `Store.send_message` gains
  `intent` kwarg with `INTENT_INVALID` validation. All SELECTs + Message
  instantiations propagate the column.
- `src/a2a_mcp_bridge/models.py` — `Message.intent: str = "triage"`.
- `src/a2a_mcp_bridge/tools.py` — `tool_agent_send(..., intent=None)`
  with `normalize_intent` + downgrade WARNING. Wake skip decision sits
  in the tool layer so `wake.py` stays semantics-agnostic.
  `_serialize_message` adds `intent` to the returned dict.
- `src/a2a_mcp_bridge/server.py` — MCP `agent_send` wrapper exposes
  the new `intent` param with a full docstring.

### Docs
- `docs/adr/ADR-002-wake-intent-coupling.md` — Status Proposed →
  Accepted. New §4.1 documents the γ scope and rationale; §5.3 open
  questions all resolved.
- `CHANGELOG.md` — `[Unreleased]` entry added with Added / Changed /
  Migration / Notes sections.

### Tests updated (minor)
- `tests/test_inbox_peek.py` + `tests/test_session_id.py` — the two
  shape-exact tests that pinned the set of keys in the inbox dict are
  updated to accept the new `intent` key. This is intentional:
  ADR-002 enriches the public inbox shape; callers that assert on
  exact keys must opt in to the new field.

## Validation

```
PYTHONPATH=src python3 -m pytest tests/
158 passed in 3.99s
```

- 150 pre-existing tests: unchanged ✓
- 8 new tests in `test_intent.py`: ✓
- 2 shape-exact tests updated to include `intent`: ✓

## Behaviour matrix

| `intent=` | Stored | Signal file | Webhook wake | Recipient session |
|---|---|---|---|---|
| (absent)   | `triage`  | ✓ | ✓ | spawns (a2a-inbox-triage) |
| `"triage"` | `triage`  | ✓ | ✓ | spawns (a2a-inbox-triage) |
| `"execute"`| `execute` | ✓ | ✓ | spawns (a2a-inbox-triage — v0.7 will dispatch differently) |
| `"review"` | `review`  | ✓ | ✓ | spawns (idem) |
| `"question"`| `question`| ✓ | ✓ | spawns (idem) |
| **`"fyi"`** | **`fyi`** | ✓ | ❌ **skip** | **none** — read at next natural `agent_inbox` |
| `"bogus"`  | `triage` (downgrade) | ✓ | ✓ | spawns; WARNING log `intent_downgraded` |

## Backward compatibility

- Pre-v0.6 databases auto-upgrade on next `Store.init_schema()` — no
  operator action required.
- Callers that omit `intent=` get **exactly** the pre-ADR-002 behaviour.
- Pre-v0.6 messages already in the DB surface as `intent: "triage"` via
  the column default.

## Out of scope (tracked elsewhere)

- The wake webhook JSON payload is **unchanged**. `intent` lives in
  the bus but is not yet forwarded to the gateway webhook — that is
  the v0.7 hook where per-intent skill dispatch lands.
- Specialised Hermes-side skills (`a2a-task-execution`,
  `a2a-review-request`) per ADR-002 §4 items 5-8 — Hermes-side
  concern, tracked separately.

## Refs

- `docs/adr/ADR-002-wake-intent-coupling.md`
- Co-authored by `VLBeauQwen` (subagent — 8/8 tests delegated with
  frozen signatures per the `delegation-strategy` skill)
