### PR TITLE
fix(issue-26): HttpBusStore sends Authorization: Bearer

### DIFF
--- a/src/a2a_mcp_bridge/bus_store.py
+++ b/src/a2a_mcp_bridge/bus_store.py
@@ -176,7 +176,13 @@ class HttpBusStore:
     """HTTP client backend for ADR-006 Step 1 — routes all bus operations
     through the remote façade server."""
 
-    def __init__(self, base_url: str, agent_id: str, timeout: float = 65.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        agent_id: str,
+        timeout: float = 65.0,
+        api_key: str | None = None,
+    ) -> None:
         try:
             import httpx as _httpx
         except ImportError as exc:
@@ -189,9 +195,14 @@ class HttpBusStore:
         self._base_url = base_url.rstrip("/")
         self._agent_id = agent_id
         self._timeout = timeout
+
+        headers: dict[str, str] = {"X-Agent-Id": agent_id}
+        if api_key is not None:
+            headers["Authorization"] = f"Bearer {api_key}"
+
         self._client = _httpx.Client(
             timeout=_httpx.Timeout(timeout),
-            headers={"X-Agent-Id": agent_id},
+            headers=headers,
         )
 
     # -- helpers ------------------------------------------------------------

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -178,12 +178,12 @@ class A2AMcp(FastMCP):
             )
 
 
-def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None, bus_url: str | None = None) -> FastMCP:
+def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None, bus_url: str | None = None, bus_api_key: str | None = None) -> FastMCP:
     if bus_url:
         # ADR-006 Step 1: remote bus via HTTP façade.
         # Import here to avoid hard dep on httpx at the top level.
         from .bus_store import HttpBusStore
-        store: BusStore = HttpBusStore(bus_url, agent_id=agent_id)
+        store: BusStore = HttpBusStore(bus_url, agent_id=agent_id, api_key=bus_api_key)
         signal_dir: SignalDir | None = None
         waker: WebhookWaker | None = None
     else:
@@ -429,6 +429,7 @@ def main(*, bus_url: str | None = None) -> None:
     agent_id = _resolve_agent_id()
     db_path = _resolve_db_path()
     signal_dir_path = _resolve_signal_dir()
+    bus_api_key = os.environ.get("A2A_FACADE_API_KEY")
     logger.info(
         "starting a2a-mcp-bridge agent_id=%s db=%s signals=%s bus_url=%s version=%s",
         agent_id,
@@ -437,7 +438,10 @@ def main(*, bus_url: str | None = None) -> None:
         bus_url or "(local)",
         _bridge_version(),
     )
-    server = build_server(agent_id, db_path, signal_dir_path, bus_url=bus_url)
+    server = build_server(
+        agent_id, db_path, signal_dir_path,
+        bus_url=bus_url, bus_api_key=bus_api_key,
+    )
     server.run()
 
 

--- a/tests/test_bus_store.py
+++ b/tests/test_bus_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -429,7 +430,7 @@ class TestApiKeyAuth:
 
         httpx.Client.__init__ = patched_client_init  # type: ignore[assignment]
         try:
-            store = HttpBusStore(
+            HttpBusStore(
                 base_url="http://localhost:8080",
                 agent_id="test-agent",
             )
@@ -451,7 +452,7 @@ class TestApiKeyAuth:
 
         httpx.Client.__init__ = patched_client_init  # type: ignore[assignment]
         try:
-            store = HttpBusStore(
+            HttpBusStore(
                 base_url="http://localhost:8080",
                 agent_id="test-agent",
                 api_key="my-secret-key",

--- a/tests/test_bus_store.py
+++ b/tests/test_bus_store.py
@@ -409,3 +409,54 @@ class TestClose:
     def test_close_calls_client_close(self, http_store, mock_client) -> None:
         http_store.close()
         mock_client.close.assert_called_once()
+
+
+class TestApiKeyAuth:
+    """Tests for the api_key parameter on HttpBusStore.__init__."""
+
+    def test_no_api_key_no_auth_header(self) -> None:
+        """Without api_key, no Authorization header is sent."""
+        captured: dict[str, str] = {}
+        _real_client_init = None
+
+        import httpx
+        _real_client_init = httpx.Client.__init__
+
+        def patched_client_init(self_client: httpx.Client, *args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs.get("headers", {}))
+            # Don't actually connect
+            return None
+
+        httpx.Client.__init__ = patched_client_init  # type: ignore[assignment]
+        try:
+            store = HttpBusStore(
+                base_url="http://localhost:8080",
+                agent_id="test-agent",
+            )
+            assert "Authorization" not in captured
+            assert captured["X-Agent-Id"] == "test-agent"
+        finally:
+            httpx.Client.__init__ = _real_client_init  # type: ignore[assignment]
+
+    def test_api_key_adds_bearer_header(self) -> None:
+        """With api_key, Authorization: Bearer <key> is sent."""
+        captured: dict[str, str] = {}
+
+        import httpx
+        _real_client_init = httpx.Client.__init__
+
+        def patched_client_init(self_client: httpx.Client, *args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs.get("headers", {}))
+            return None
+
+        httpx.Client.__init__ = patched_client_init  # type: ignore[assignment]
+        try:
+            store = HttpBusStore(
+                base_url="http://localhost:8080",
+                agent_id="test-agent",
+                api_key="my-secret-key",
+            )
+            assert captured["Authorization"] == "Bearer my-secret-key"
+            assert captured["X-Agent-Id"] == "test-agent"
+        finally:
+            httpx.Client.__init__ = _real_client_init  # type: ignore[assignment]


### PR DESCRIPTION
Bug trouvé par Opus : `HttpBusStore` ne lisait pas `A2A_FACADE_API_KEY` et n'envoyait jamais le header `Authorization: Bearer`. Un client distant avec `--api-key` sur la facade prenait systématiquement du 401.

**Fix:**
- `bus_store.py` : param `api_key` sur `__init__` → header `Authorization: Bearer <key>`
- `server.py` : `build_server()` accepte `bus_api_key`, `main()` lit `A2A_FACADE_API_KEY`
- 2 tests : sans clé = pas d'auth header, avec clé = Bearer présent

**212/212 tests verts**, ruff clean.