### PR TITLE
fix: defensive metadata JSON validation in Store

### DIFF
--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -275,10 +275,10 @@ class Store:
                 # Caller passed a raw JSON string — validate it parses.
                 try:
                     json.loads(metadata)
-                except json.JSONDecodeError:
+                except json.JSONDecodeError as e:
                     raise ValueError(
                         "METADATA_INVALID: metadata string is not valid JSON"
-                    )
+                    ) from e
                 metadata_json = metadata
             elif isinstance(metadata, dict):
                 metadata_json = json.dumps(metadata, separators=(",", ":"))

--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -25,6 +26,8 @@ from .models import (
 from .signals import SignalDir
 
 SCHEMA_PATH: Path = Path(__file__).parent / "schema.sql"
+
+logger = logging.getLogger(__name__)
 
 
 class Store:
@@ -157,12 +160,23 @@ class Store:
         Used by :meth:`read_inbox` and :meth:`peek_inbox` to eliminate
         duplication.
         """
+        metadata: dict[str, Any] | None = None
+        if r["metadata"]:
+            try:
+                metadata = json.loads(r["metadata"])
+            except json.JSONDecodeError:
+                logger.warning(
+                    "metadata JSON corrupt for message %s, returning None",
+                    r["id"],
+                )
+                metadata = None
+
         return Message(
             id=r["id"],
             sender_id=r["sender_id"],
             recipient_id=r["recipient_id"],
             body=r["body"],
-            metadata=json.loads(r["metadata"]) if r["metadata"] else None,
+            metadata=metadata,
             created_at=datetime.fromisoformat(r["created_at"]),
             read_at=datetime.fromisoformat(r["read_at"]) if r["read_at"] else None,
             sender_session_id=r["sender_session_id"],
@@ -257,7 +271,21 @@ class Store:
 
         metadata_json: str | None = None
         if metadata is not None:
-            metadata_json = json.dumps(metadata, separators=(",", ":"))
+            if isinstance(metadata, str):
+                # Caller passed a raw JSON string — validate it parses.
+                try:
+                    json.loads(metadata)
+                except json.JSONDecodeError:
+                    raise ValueError(
+                        "METADATA_INVALID: metadata string is not valid JSON"
+                    )
+                metadata_json = metadata
+            elif isinstance(metadata, dict):
+                metadata_json = json.dumps(metadata, separators=(",", ":"))
+            else:
+                raise ValueError(
+                    "METADATA_INVALID: metadata must be a dict, a JSON string, or None"
+                )
             if len(metadata_json.encode("utf-8")) > MAX_METADATA_BYTES:
                 raise ValueError(f"METADATA_TOO_LARGE: metadata exceeds {MAX_METADATA_BYTES} bytes")
 

--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -1,6 +1,5 @@
 """Tests for metadata JSON validation and defensive parsing."""
 
-import json
 import logging
 
 import pytest

--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -1,0 +1,82 @@
+"""Tests for metadata JSON validation and defensive parsing."""
+
+import json
+import logging
+
+import pytest
+
+from a2a_mcp_bridge.store import Store
+
+
+class TestMetadataValidationOnSend:
+    """send_message must validate metadata before INSERT."""
+
+    def test_valid_dict_metadata(self, store: Store) -> None:
+        """A dict metadata is serialised and round-trips correctly."""
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+
+        meta = {"session_id": "abc123", "tag": "e2e"}
+        result = store.send_message(
+            sender="alice", recipient="bob", body="hi", metadata=meta,
+        )
+        assert result.message_id
+
+        inbox = store.read_inbox("bob", limit=10, unread_only=True)
+        assert len(inbox) == 1
+        assert inbox[0].metadata == meta
+
+    def test_invalid_json_string_metadata_raises(self, store: Store) -> None:
+        """A string metadata that is not valid JSON raises METADATA_INVALID."""
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+
+        with pytest.raises(ValueError, match="METADATA_INVALID"):
+            store.send_message(
+                sender="alice",
+                recipient="bob",
+                body="hi",
+                metadata="{'single': 'quotes'}",  # not valid JSON
+            )
+
+    def test_none_metadata_round_trips(self, store: Store) -> None:
+        """metadata=None is stored as NULL and reads back as None."""
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+
+        result = store.send_message(
+            sender="alice", recipient="bob", body="hi", metadata=None,
+        )
+        assert result.message_id
+
+        inbox = store.read_inbox("bob", limit=10, unread_only=True)
+        assert len(inbox) == 1
+        assert inbox[0].metadata is None
+
+
+class TestMetadataCorruptRecovery:
+    """_row_to_message must not crash on corrupt JSON in the DB."""
+
+    def test_corrupt_metadata_returns_none(self, store: Store, caplog: pytest.LogCaptureFixture) -> None:
+        """If the DB holds invalid JSON, _row_to_message returns metadata=None."""
+        store.upsert_agent("alice")
+        store.upsert_agent("bob")
+
+        # Insert a message with valid metadata first.
+        store.send_message(
+            sender="alice", recipient="bob", body="hi",
+            metadata={"ok": True},
+        )
+
+        # Corrupt the metadata column directly in SQLite.
+        store._conn.execute(
+            "UPDATE messages SET metadata = ? WHERE recipient_id = ?",
+            ("{'single': 'quotes'}", "bob"),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            inbox = store.read_inbox("bob", limit=10, unread_only=False)
+
+        assert len(inbox) == 1
+        assert inbox[0].metadata is None
+        assert "corrupt" in caplog.text.lower()


### PR DESCRIPTION
## Summary

Defensive handling of the `metadata` column: no more crashes on corrupt JSON.

### Changes

**store.py — _row_to_message**
- Wrap `json.loads(r["metadata"])` in `try/except JSONDecodeError`
- Log a WARNING with the message ID
- Return `metadata=None` instead of crashing

**store.py — send_message**
- Accept `dict` → `json.dumps(metadata)`
- Accept `str` → validate with `json.loads(metadata)`, raise `ValueError("METADATA_INVALID")` if invalid
- Any other type → `ValueError("METADATA_INVALID")`

**facade.py**
- No patch needed: inbox_peek_handler and inbox_handler both go through _row_to_message, which is now protected.

### Tests (4 new)

| Test | Description |
|---|---|
| test_valid_dict_metadata | Dict metadata serialises and round-trips correctly |
| test_invalid_json_string_metadata_raises | Single-quoted JSON string raises METADATA_INVALID |
| test_none_metadata_round_trips | metadata=None stores as NULL, reads back as None |
| test_corrupt_metadata_returns_none | Corrupt JSON in DB → metadata=None + WARNING log |

All 216 tests pass.