### PR TITLE
feat: stale-wake-registry — reload waker on mtime change

### DIFF
--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -125,6 +125,55 @@ def _load_waker() -> WebhookWaker | None:
     return WebhookWaker(registry, shared_secret=shared_secret)
 
 
+# Module-level cache for _load_waker_if_stale: (waker, mtime) tuple.
+_waker_cache: tuple[WebhookWaker | None, float] | None = None
+
+
+def _load_waker_if_stale() -> WebhookWaker | None:
+    """Return a cached waker, reloading if the registry file's mtime changed.
+
+    On the first call (or after :func:`_reset_waker_cache`), the registry is
+    loaded unconditionally. On subsequent calls, the file's mtime is compared
+    to the cached value. If the mtime differs, the waker is reloaded; otherwise
+    the cached instance is returned.
+
+    This allows long-running bridge processes to pick up registry changes
+    (e.g. new agents added by the CLI) without restarting.
+    """
+    global _waker_cache
+    path = _resolve_wake_registry_path()
+    try:
+        current_mtime = Path(path).stat().st_mtime
+    except OSError:
+        # File missing or unreadable: if we have a cached waker it's stale,
+        # otherwise just load (which returns None for missing files).
+        if _waker_cache is not None:
+            logger.info("wake registry %s gone, clearing cache", path)
+            _waker_cache = None
+        return _load_waker()
+
+    if _waker_cache is not None:
+        cached_waker, cached_mtime = _waker_cache
+        if cached_mtime == current_mtime:
+            return cached_waker
+        logger.info(
+            "wake registry %s mtime changed (%s -> %s), reloading",
+            path,
+            cached_mtime,
+            current_mtime,
+        )
+
+    waker = _load_waker()
+    _waker_cache = (waker, current_mtime)
+    return waker
+
+
+def _reset_waker_cache() -> None:
+    """Clear the module-level waker cache (for testing)."""
+    global _waker_cache
+    _waker_cache = None
+
+
 class A2AMcp(FastMCP):
     """FastMCP subclass that advertises ``tools.listChanged`` capability.
 
@@ -191,7 +240,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         store = Store(db_path, signal_dir=sd)
         store.init_schema()
         signal_dir = sd
-        waker = _load_waker()
+        waker = _load_waker_if_stale()
     store.upsert_agent(agent_id)
 
     mcp = A2AMcp("a2a-mcp-bridge")
@@ -243,7 +292,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         local gateway endpoint. SKIPPED for ``intent=fyi`` (ADR-002).
         """
         return tool_agent_send(
-            store, agent_id, target, message, metadata, signal_dir, waker,
+            store, agent_id, target, message, metadata, signal_dir, _load_waker_if_stale(),
             intent=intent,
         )
 

--- a/tests/test_stale_wake_registry.py
+++ b/tests/test_stale_wake_registry.py
@@ -1,0 +1,98 @@
+"""Tests for _load_waker_if_stale — reload waker on mtime change."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from a2a_mcp_bridge import server as server_module
+from a2a_mcp_bridge.wake import WebhookWaker
+
+
+def _write_registry(path: Path, agents: dict[str, str], secret: str = "secret64" * 8) -> None:
+    """Write a valid v0.4.4 webhook registry to *path*."""
+    path.write_text(
+        json.dumps(
+            {
+                "wake_webhook_secret": secret,
+                "agents": {
+                    aid: {"wake_webhook_url": url} for aid, url in agents.items()
+                },
+            }
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Ensure the module-level cache is cleared before and after every test."""
+    server_module._reset_waker_cache()
+    yield
+    server_module._reset_waker_cache()
+
+
+@pytest.fixture
+def reg_path(tmp_path: Path) -> Path:
+    return tmp_path / "wake.json"
+
+
+class TestLoadWakerIfStale:
+    def test_first_call_loads_waker(self, reg_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On the first call, the waker is loaded from disk."""
+        monkeypatch.setenv("A2A_WAKE_REGISTRY", str(reg_path))
+        _write_registry(reg_path, {"alice": "http://127.0.0.1:8700/webhooks/wake"})
+
+        waker = server_module._load_waker_if_stale()
+        assert waker is not None
+        assert isinstance(waker, WebhookWaker)
+        assert waker.has("alice")
+
+    def test_cached_waker_returned_when_mtime_unchanged(
+        self, reg_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the file mtime has not changed, the same waker object is returned."""
+        monkeypatch.setenv("A2A_WAKE_REGISTRY", str(reg_path))
+        _write_registry(reg_path, {"alice": "http://127.0.0.1:8700/webhooks/wake"})
+
+        waker1 = server_module._load_waker_if_stale()
+        waker2 = server_module._load_waker_if_stale()
+        assert waker1 is waker2
+
+    def test_waker_reloaded_on_mtime_change(
+        self, reg_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the file mtime changes (new content), the waker is reloaded."""
+        monkeypatch.setenv("A2A_WAKE_REGISTRY", str(reg_path))
+        _write_registry(reg_path, {"alice": "http://127.0.0.1:8700/webhooks/wake"})
+
+        waker1 = server_module._load_waker_if_stale()
+        assert waker1 is not None
+        assert waker1.has("alice")
+        assert not waker1.has("bob")
+
+        # Ensure a different mtime by writing new content and guaranteeing
+        # the filesystem mtime ticks forward.
+        time.sleep(0.05)
+        _write_registry(
+            reg_path,
+            {
+                "alice": "http://127.0.0.1:8700/webhooks/wake",
+                "bob": "http://127.0.0.1:8701/webhooks/wake",
+            },
+        )
+        # Force a different mtime on filesystems with low resolution.
+        # On most Linux this is unnecessary but makes the test robust on
+        # platforms with 1s mtime granularity.
+        import os
+        os.utime(str(reg_path))
+
+        waker2 = server_module._load_waker_if_stale()
+        assert waker2 is not None
+        # Must be a new object (reloaded).
+        assert waker2 is not waker1
+        # And must contain the new agent.
+        assert waker2.has("bob")


### PR DESCRIPTION
## Summary

Remplace le cache statique de _load_waker() par un _load_waker_if_stale() qui vérifie le mtime du fichier registry avant chaque agent_send. Si le fichier a changé, recharge le waker. Sinon retourne le waker en cache.

## Changes

- **server.py**: ajout de _load_waker_if_stale() + _waker_cache module-level + _reset_waker_cache()
- **server.py**: agent_send() appelle _load_waker_if_stale() à chaque envoi (plus de closure statique)
- **server.py**: build_server() appelle _load_waker_if_stale() au lieu de _load_waker()
- **tests/test_stale_wake_registry.py**: 3 tests (first load, cache hit, reload on mtime change)

## Why

Les bridges longue durée (systemd) ne pickent pas les changements de registry sans restart. Avec ce change, un wake-registry add CLI est pris en compte au prochain agent_send sans restart.

## Test

```
PYTHONPATH=src python3 -m pytest tests/test_stale_wake_registry.py -v
3 passed
```