### PR TITLE
feat(rate-limit): memory guard + /health and /ping exemption (v0.6.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.6.1"
+version = "0.6.2"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/rate_limit.py
+++ b/src/a2a_mcp_bridge/rate_limit.py
@@ -1,4 +1,4 @@
-"""Configurable rate limiter for the HTTP façade (audit recommendation).
+"""Configurable rate limiter for the HTTP facade (audit recommendation).
 
 Uses a sliding-window algorithm with per-key (IP) counters. No external
 dependencies — pure stdlib.
@@ -22,6 +22,9 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_MAX_HITS_KEYS = 10_000  # hard limit — GC triggered when dict grows past this
+_PRUNE_INTERVAL_S = 60.0  # seconds between periodic stale-entry sweeps
+
 
 def _env_int(name: str, default: int) -> int:
     raw = os.environ.get(name, "").strip()
@@ -44,11 +47,16 @@ class RateLimiter:
 
     The ``hits`` dict stores a list of ``time.monotonic()`` timestamps
     for each key. On every ``allow()`` call, timestamps older than 60 s
-    are pruned from the window.
+    are pruned from the window. A periodic stale-entry sweep runs every
+    ``_PRUNE_INTERVAL_S`` (60 s) to garbage-collect entries that have
+    no active timestamps left. When the dict grows past ``_MAX_HITS_KEYS``
+    (10 000), an immediate full sweep is triggered to prevent unbounded
+    memory growth from transient IPs.
     """
 
     rpm: int
     hits: dict[str, list[float]] = field(default_factory=lambda: defaultdict(list))
+    _last_prune: float = field(default=-1.0, init=False, repr=False)
 
     @property
     def enabled(self) -> bool:
@@ -69,11 +77,61 @@ class RateLimiter:
         window = [t for t in self.hits[key] if t > cutoff]
         self.hits[key] = window
 
+        # Lazy init of _last_prune on the very first call — avoids a spurious
+        # sweep at startup (when `now - 0.0` always exceeds the interval).
+        if self._last_prune < 0:
+            self._last_prune = now
+
+        # Periodic stale-entry sweep. Triggers:
+        # 1. Every _PRUNE_INTERVAL_S (60 s) — lightweight, catches slow leaks.
+        # 2. When the dict exceeds _MAX_HITS_KEYS — aggressive, prevents OOM.
+        # _last_prune is bumped in both cases so the two triggers don't fire
+        # redundantly back-to-back.
+        if (
+            len(self.hits) > _MAX_HITS_KEYS
+            or now - self._last_prune >= _PRUNE_INTERVAL_S
+        ):
+            self.prune_stale()
+            self._last_prune = now
+
         if len(window) >= self.rpm:
             return False
 
         window.append(now)
         return True
+
+    def prune_stale(self) -> int:
+        """Remove entries whose timestamps have all expired.
+
+        Only entries with non-empty timestamp lists are considered;
+        entries with empty lists are transient (being processed in the
+        current ``allow()`` call) and are skipped.
+
+        Returns:
+            Number of entries removed.
+        """
+        now = time.monotonic()
+        cutoff = now - 60.0
+        stale = [
+            k for k, timestamps in self.hits.items()
+            if timestamps and not any(t > cutoff for t in timestamps)
+        ]
+        for k in stale:
+            del self.hits[k]
+        if stale:
+            logger.debug("prune_stale removed %d entries from %d", len(stale), len(self.hits) + len(stale))
+        return len(stale)
+
+    def cleanup(self) -> int:
+        """Aggressive cleanup: remove ALL stale entries.
+
+        Alias for :meth:`prune_stale`. Kept for backwards compatibility
+        and for external callers that prefer the name.
+
+        Returns:
+            Number of entries removed.
+        """
+        return self.prune_stale()
 
     def reset(self, key: str) -> None:
         """Clear all hits for *key* (useful for testing)."""
@@ -87,7 +145,7 @@ class RateLimiter:
 
 @dataclass
 class FacadeRateLimiters:
-    """Holds per-route :class:`RateLimiter` instances for the façade.
+    """Holds per-route :class:`RateLimiter` instances for the facade.
 
     The *global_* limiter is applied first (before the per-route one)
     so that an IP flooding any endpoint gets a 429 regardless.
@@ -98,8 +156,26 @@ class FacadeRateLimiters:
     inbox: RateLimiter
     register: RateLimiter
 
+    @staticmethod
+    def disabled() -> FacadeRateLimiters:
+        """Return a no-op instance (all RPMs set to 0).
+
+        Useful for tests and development mode where rate limiting
+        should be entirely bypassed without environment variables.
+        """
+        return FacadeRateLimiters(
+            global_=RateLimiter(0),
+            send=RateLimiter(0),
+            inbox=RateLimiter(0),
+            register=RateLimiter(0),
+        )
+
     def for_route(self, route: str) -> RateLimiter | None:
-        """Return the per-route limiter or ``None`` for unknown routes."""
+        """Return the per-route limiter or ``None`` for unknown routes.
+
+        Trailing slashes are stripped for robustness.
+        """
+        route = route.rstrip("/")
         if route == "/send":
             return self.send
         if route in ("/inbox", "/inbox_peek"):
@@ -107,6 +183,21 @@ class FacadeRateLimiters:
         if route == "/register":
             return self.register
         return None
+
+    def prune_stale(self) -> int:
+        """Sweep stale entries across all sub-limiters.
+
+        Returns:
+            Total number of entries removed.
+        """
+        total = 0
+        total += self.global_.prune_stale()
+        total += self.send.prune_stale()
+        total += self.inbox.prune_stale()
+        total += self.register.prune_stale()
+        if total:
+            logger.debug("FacadeRateLimiters.prune_stale removed %d entries total", total)
+        return total
 
 
 def build_limiters() -> FacadeRateLimiters:
@@ -130,6 +221,21 @@ def build_limiters() -> FacadeRateLimiters:
 # The ``facade`` module imports this function and wraps it as a FastAPI
 # HTTP middleware. It is kept here so unit tests can exercise the logic
 # without launching a full ASGI app.
+
+# Routes exempt from rate limiting — health checks and monitoring
+# should never be blocked even when an IP is flooding.
+_EXEMPT_ROUTES: frozenset[str] = frozenset({"/health", "/ping"})
+
+
+def _should_skip_rate_limit(route: str) -> bool:
+    """Return ``True`` if *route* should bypass rate limiting.
+
+    Currently exempts ``/health`` and ``/ping`` so that monitoring
+    tooling never sees a 429. Trailing slashes are stripped before
+    matching (``/health/`` is treated as ``/health``).
+    """
+    return route.rstrip("/") in _EXEMPT_ROUTES
+
 
 def ratelimit_middleware_factory(
     limiters: FacadeRateLimiters,
@@ -171,22 +277,25 @@ def ratelimit_middleware_factory(
         ip = get_client_ip(request)
         route = request.url.path
 
-        # Global limit first — applies to every request.
-        if not limiters.global_.allow(ip):
-            return JSONResponse(
-                {"error": {"code": "RATE_LIMITED", "message": "Too many requests"}},
-                status_code=429,
-                headers={"Retry-After": "60"},
-            )
+        # Health and monitoring endpoints are never rate-limited.
+        if not _should_skip_rate_limit(route):
 
-        # Per-route limit (if configured).
-        route_limiter = limiters.for_route(route)
-        if route_limiter is not None and not route_limiter.allow(ip):
-            return JSONResponse(
-                {"error": {"code": "RATE_LIMITED", "message": "Too many requests"}},
-                status_code=429,
-                headers={"Retry-After": "60"},
-            )
+            # Global limit first — applies to every request.
+            if not limiters.global_.allow(ip):
+                return JSONResponse(
+                    {"error": {"code": "RATE_LIMITED", "message": "Too many requests"}},
+                    status_code=429,
+                    headers={"Retry-After": "60"},
+                )
+
+            # Per-route limit (if configured).
+            route_limiter = limiters.for_route(route)
+            if route_limiter is not None and not route_limiter.allow(ip):
+                return JSONResponse(
+                    {"error": {"code": "RATE_LIMITED", "message": "Too many requests"}},
+                    status_code=429,
+                    headers={"Retry-After": "60"},
+                )
 
         return await call_next(request)
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -11,6 +11,7 @@ import pytest
 from a2a_mcp_bridge.rate_limit import (
     FacadeRateLimiters,
     RateLimiter,
+    _should_skip_rate_limit,
     build_limiters,
     ratelimit_middleware_factory,
 )
@@ -52,33 +53,142 @@ class TestRateLimiter:
     def test_window_slides_with_expired_timestamps(self, monkeypatch: pytest.MonkeyPatch) -> None:
         rl = RateLimiter(rpm=2)
 
-        # Mock time.monotonic to control the sliding window.
         now = 1000.0
         monkeypatch.setattr(time, "monotonic", lambda: now)
 
-        # Fill up the window.
         rl.allow("k")
         monkeypatch.setattr(time, "monotonic", lambda: now + 1)
         rl.allow("k")
         monkeypatch.setattr(time, "monotonic", lambda: now + 2)
         assert rl.allow("k") is False  # still full
 
-        # Jump 61 seconds forward — first two timestamps expire.
         monkeypatch.setattr(time, "monotonic", lambda: now + 61)
-        assert rl.allow("k") is True  # window opened
-        assert rl.allow("k") is True  # second slot
-        assert rl.allow("k") is False  # full again
+        assert rl.allow("k") is True
+        assert rl.allow("k") is True
+        assert rl.allow("k") is False
 
     def test_multiple_keys_independent(self) -> None:
         rl = RateLimiter(rpm=1)
         assert rl.allow("ip1") is True
-        assert rl.allow("ip1") is False  # ip1 blocked
-        assert rl.allow("ip2") is True   # ip2 unaffected
+        assert rl.allow("ip1") is False
+        assert rl.allow("ip2") is True
         assert rl.allow("ip2") is False
 
     def test_enabled_property(self) -> None:
         assert RateLimiter(rpm=0).enabled is False
         assert RateLimiter(rpm=1).enabled is True
+
+    def test_hits_dict_garbage_collection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the hits dict grows past _MAX_HITS_KEYS, stale entries are pruned."""
+        # Use a very small limit by patching the module constant.
+        from a2a_mcp_bridge import rate_limit as _rl
+
+        monkeypatch.setattr(_rl, "_MAX_HITS_KEYS", 3)
+        # Disable time-based GC so it doesn't interfere.
+        monkeypatch.setattr(_rl, "_PRUNE_INTERVAL_S", 9999.0)
+
+        rl = RateLimiter(rpm=100)
+        # Fill 3 keys, then expire them by advancing time.
+        now = 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        rl.allow("a")
+        rl.allow("b")
+        rl.allow("c")
+
+        # All 3 keys in dict.
+        assert len(rl.hits) == 3
+
+        # Advance past 60s so all timestamps expire.
+        monkeypatch.setattr(time, "monotonic", lambda: now + 61)
+
+        # This call triggers GC (len > 3).
+        rl.allow("d")
+        # "a", "b", "c" should be removed, only "d" remains.
+        assert len(rl.hits) == 1
+        assert "d" in rl.hits
+        assert "a" not in rl.hits
+        assert "b" not in rl.hits
+        assert "c" not in rl.hits
+
+    def test_prune_stale_removes_expired_entries(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """prune_stale() removes entries where all timestamps are expired."""
+        rl = RateLimiter(rpm=100)
+        now = 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        rl.allow("a")
+        rl.allow("b")
+        assert len(rl.hits) == 2
+
+        # Advance past 60s.
+        monkeypatch.setattr(time, "monotonic", lambda: now + 61)
+        removed = rl.prune_stale()
+        assert removed == 2
+        assert len(rl.hits) == 0
+
+    def test_prune_stale_preserves_fresh_entries(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """prune_stale() keeps entries with active timestamps."""
+        rl = RateLimiter(rpm=100)
+        now = 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        rl.allow("old")  # timestamp 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now + 30)
+        rl.allow("fresh")  # timestamp 1030.0
+
+        monkeypatch.setattr(time, "monotonic", lambda: now + 61)
+        # cutoff = 1061 - 60 = 1001. "old" at 1000 is stale, "fresh" at 1030 is active.
+        removed = rl.prune_stale()
+        assert removed == 1
+        assert "old" not in rl.hits
+        assert "fresh" in rl.hits
+
+    def test_cleanup_is_alias_for_prune_stale(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cleanup() delegates to prune_stale()."""
+        rl = RateLimiter(rpm=100)
+        now = 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        rl.allow("x")
+        monkeypatch.setattr(time, "monotonic", lambda: now + 61)
+        removed = rl.cleanup()
+        assert removed == 1
+        assert len(rl.hits) == 0
+
+    def test_time_based_gc_triggers_periodically(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Periodic GC runs when _PRUNE_INTERVAL_S has elapsed."""
+        from a2a_mcp_bridge import rate_limit as _rl
+
+        monkeypatch.setattr(_rl, "_MAX_HITS_KEYS", 999_999)
+        monkeypatch.setattr(_rl, "_PRUNE_INTERVAL_S", 20.0)
+
+        rl = RateLimiter(rpm=100)
+        now = 1000.0
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        rl.allow("stale-key")
+        # After first allow(), time-based GC already ran (1000 - 0 >= 20),
+        # so _last_prune should be set to now.
+        assert rl._last_prune == 1000.0
+
+        # Advance just 5s — not enough for time-based GC.
+        monkeypatch.setattr(time, "monotonic", lambda: now + 5)
+        rl.allow("another-key")
+        assert rl._last_prune == 1000.0  # unchanged
+
+        # Advance past 60s relative to stale-key (1000 → now+64 = 1064),
+        # but keep another-key (1005) inside the 60s window (59s old).
+        monkeypatch.setattr(time, "monotonic", lambda: now + 64)
+        rl.allow("third-key")
+        # Time-based GC should have triggered (64s elapsed since last prune).
+        assert rl._last_prune == now + 64
+        assert "stale-key" not in rl.hits
+        assert "another-key" in rl.hits
+        assert "third-key" in rl.hits
 
 
 # ---------------------------------------------------------------------------
@@ -113,7 +223,7 @@ class TestBuildLimiters:
 
 
 # ---------------------------------------------------------------------------
-# FacadeRateLimiters.for_route tests
+# FacadeRateLimiters tests
 # ---------------------------------------------------------------------------
 
 
@@ -129,10 +239,91 @@ class TestFacadeRateLimiters:
         assert limiters.for_route("/inbox") is limiters.inbox
         assert limiters.for_route("/inbox_peek") is limiters.inbox
         assert limiters.for_route("/register") is limiters.register
-        # Unknown routes return None
         assert limiters.for_route("/health") is None
         assert limiters.for_route("/ping") is None
         assert limiters.for_route("/subscribe") is None
+
+    def test_for_route_strips_trailing_slash(self) -> None:
+        """for_route handles routes with trailing slashes."""
+        limiters = FacadeRateLimiters(
+            global_=RateLimiter(100),
+            send=RateLimiter(10),
+            inbox=RateLimiter(20),
+            register=RateLimiter(5),
+        )
+        assert limiters.for_route("/send/") is limiters.send
+        assert limiters.for_route("/inbox/") is limiters.inbox
+        assert limiters.for_route("/register/") is limiters.register
+        # /health is not mapped by for_route, but it should still return None
+        assert limiters.for_route("/health/") is None
+
+    def test_disabled_factory_all_zero(self) -> None:
+        dl = FacadeRateLimiters.disabled()
+        assert dl.global_.rpm == 0
+        assert dl.send.rpm == 0
+        assert dl.inbox.rpm == 0
+        assert dl.register.rpm == 0
+        assert dl.global_.enabled is False
+
+    def test_disabled_always_allows(self) -> None:
+        dl = FacadeRateLimiters.disabled()
+        for _ in range(100):
+            assert dl.global_.allow("any") is True
+            assert dl.send.allow("any") is True
+
+    def test_prune_stale_delegates_to_all_limiters(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """FacadeRateLimiters.prune_stale() calls prune_stale on each sub-limiter."""
+        import time as _time_module
+
+        limiters = FacadeRateLimiters(
+            global_=RateLimiter(100),
+            send=RateLimiter(100),
+            inbox=RateLimiter(100),
+            register=RateLimiter(100),
+        )
+        now = 1000.0
+        monkeypatch.setattr(_time_module, "monotonic", lambda: now)
+        limiters.global_.allow("ip1")
+        limiters.send.allow("ip2")
+        limiters.inbox.allow("ip3")
+
+        # Expire all timestamps.
+        monkeypatch.setattr(_time_module, "monotonic", lambda: now + 61)
+        total = limiters.prune_stale()
+        assert total == 3
+        assert len(limiters.global_.hits) == 0
+        assert len(limiters.send.hits) == 0
+        assert len(limiters.inbox.hits) == 0
+
+
+# ---------------------------------------------------------------------------
+# _should_skip_rate_limit tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSkipRateLimit:
+    def test_health_and_ping_exempted(self) -> None:
+        assert _should_skip_rate_limit("/health") is True
+        assert _should_skip_rate_limit("/ping") is True
+
+    def test_other_routes_not_exempted(self) -> None:
+        assert _should_skip_rate_limit("/send") is False
+        assert _should_skip_rate_limit("/inbox") is False
+        assert _should_skip_rate_limit("/register") is False
+        assert _should_skip_rate_limit("/subscribe") is False
+        assert _should_skip_rate_limit("/") is False
+
+    def test_trailing_slash_exempted(self) -> None:
+        """Trailing slashes on exempt routes are still exempted."""
+        assert _should_skip_rate_limit("/health/") is True
+        assert _should_skip_rate_limit("/ping/") is True
+
+    def test_trailing_slash_not_exempted_for_other_routes(self) -> None:
+        """Trailing slashes don't make non-exempt routes exempt."""
+        assert _should_skip_rate_limit("/send/") is False
+        assert _should_skip_rate_limit("/inbox/") is False
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +354,6 @@ class TestRatelimitMiddleware:
         call_next = AsyncMock()
 
         resp = await dispatch(req, call_next)
-        # Middleware calls call_next and returns its result when allowed.
         assert call_next.called
         assert resp is call_next.return_value
 
@@ -176,14 +366,13 @@ class TestRatelimitMiddleware:
         )
         dispatch = ratelimit_middleware_factory(limiters)
 
-        req = self._make_request("10.0.0.1", "/ping")
+        # Use /subscribe — not exempted, has no per-route limiter (uses global only).
+        req = self._make_request("10.0.0.1", "/subscribe")
         call_next = AsyncMock()
 
-        # First 2 requests pass.
         await dispatch(req, call_next)
         await dispatch(req, call_next)
 
-        # Third request blocked by global limit.
         resp = await dispatch(req, call_next)
         assert resp.status_code == 429
         data = json.loads(resp.body)
@@ -202,11 +391,9 @@ class TestRatelimitMiddleware:
         req = self._make_request("10.0.0.2", "/send")
         call_next = AsyncMock()
 
-        # First 2 /send requests pass.
         await dispatch(req, call_next)
         await dispatch(req, call_next)
 
-        # Third /send request blocked by per-route limit.
         resp = await dispatch(req, call_next)
         assert resp.status_code == 429
 
@@ -223,12 +410,58 @@ class TestRatelimitMiddleware:
         req_b = self._make_request("2.2.2.2", "/send")
         call_next = AsyncMock()
 
-        # IP A fills global quota.
         await dispatch(req_a, call_next)
-        # IP A blocked.
         resp = await dispatch(req_a, call_next)
         assert resp.status_code == 429
 
-        # IP B still allowed (different key).
         resp_b = await dispatch(req_b, call_next)
         assert resp_b.status_code != 429
+
+    async def test_health_never_blocked_by_global_limit(self) -> None:
+        """Health/ping bypass rate limiting even when global limit is exceeded."""
+        limiters = FacadeRateLimiters(
+            global_=RateLimiter(1),
+            send=RateLimiter(100),
+            inbox=RateLimiter(100),
+            register=RateLimiter(100),
+        )
+        dispatch = ratelimit_middleware_factory(limiters)
+        call_next = AsyncMock()
+
+        # Exhaust global limit with /send
+        req_send = self._make_request("10.0.0.1", "/send")
+        await dispatch(req_send, call_next)
+        resp = await dispatch(req_send, call_next)
+        assert resp.status_code == 429  # blocked
+
+        # /health still passes
+        req_health = self._make_request("10.0.0.1", "/health")
+        resp_health = await dispatch(req_health, call_next)
+        assert resp_health.status_code != 429
+
+        # /ping still passes
+        req_ping = self._make_request("10.0.0.1", "/ping")
+        resp_ping = await dispatch(req_ping, call_next)
+        assert resp_ping.status_code != 429
+
+    async def test_health_with_trailing_slash_exempted(self) -> None:
+        """/health/ (trailing slash) also bypasses rate limiting."""
+        limiters = FacadeRateLimiters(
+            global_=RateLimiter(1),
+            send=RateLimiter(100),
+            inbox=RateLimiter(100),
+            register=RateLimiter(100),
+        )
+        dispatch = ratelimit_middleware_factory(limiters)
+        call_next = AsyncMock()
+
+        # Exhaust global limit
+        req_send = self._make_request("10.0.0.1", "/send")
+        await dispatch(req_send, call_next)
+        resp = await dispatch(req_send, call_next)
+        assert resp.status_code == 429
+
+        # /health/ with trailing slash still passes
+        req_health_slash = self._make_request("10.0.0.1", "/health/")
+        resp_health = await dispatch(req_health_slash, call_next)
+        assert resp_health.status_code != 429

--- a/tests/test_rate_limit_integration.py
+++ b/tests/test_rate_limit_integration.py
@@ -1,0 +1,290 @@
+"""Integration tests for rate limiting against a real uvicorn server.
+
+Verifies that the façade returns 429 + Retry-After when limits are
+exceeded, using real HTTP requests (not mocked middleware).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+_RATE_LIMIT_PORT = 18768  # high port to avoid collisions
+
+
+@pytest.fixture(scope="module")
+def facade_rate_limited() -> str:
+    """Start uvicorn with A2A_RATE_LIMIT_SEND=3 for the test module."""
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn",
+            "a2a_mcp_bridge.facade:create_app",
+            "--host", "127.0.0.1",
+            "--port", str(_RATE_LIMIT_PORT),
+            "--factory",
+        ],
+        env={
+            **os.environ,
+            "PYTHONPATH": "src",
+            "A2A_RATE_LIMIT_GLOBAL": "200",
+            "A2A_RATE_LIMIT_SEND": "3",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    base_url = f"http://127.0.0.1:{_RATE_LIMIT_PORT}"
+    deadline = time.monotonic() + 8.0
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=1.0)
+            if resp.status_code == 200:
+                break
+        except (httpx.ConnectError, httpx.ReadTimeout):
+            pass
+        time.sleep(0.15)
+    else:
+        proc.kill()
+        _out, err = proc.communicate(timeout=5)
+        pytest.fail(
+            f"Rate-limited façade did not start on port {_RATE_LIMIT_PORT}:\n"
+            f"stderr: {err.decode()}"
+        )
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+class TestRateLimitIntegration:
+    """Real HTTP rate limiting against a live uvicorn server."""
+
+    def test_send_limit_returns_429_with_retry_after(
+        self, facade_rate_limited: str
+    ) -> None:
+        base = facade_rate_limited
+
+        # Register agents so /send targets are valid.
+        for agent_id in ("alice", "bob"):
+            httpx.post(f"{base}/register", json={"agent_id": agent_id})
+
+        payload = {"sender": "alice", "recipient": "bob", "body": "test"}
+
+        # First 3 requests should pass (A2A_RATE_LIMIT_SEND=3).
+        for _ in range(3):
+            resp = httpx.post(f"{base}/send", json=payload)
+            assert resp.status_code == 200, (
+                f"Expected 200, got {resp.status_code}: {resp.json()}"
+            )
+
+        # 4th request should be blocked.
+        resp = httpx.post(f"{base}/send", json=payload)
+        assert resp.status_code == 429
+        data = resp.json()
+        assert data["error"]["code"] == "RATE_LIMITED"
+        assert resp.headers.get("Retry-After") == "60"
+
+        # 5th request also blocked.
+        resp = httpx.post(f"{base}/send", json=payload)
+        assert resp.status_code == 429
+
+    def test_health_never_rate_limited(
+        self, facade_rate_limited: str
+    ) -> None:
+        base = facade_rate_limited
+        for _ in range(20):
+            resp = httpx.get(f"{base}/health")
+            assert resp.status_code == 200, (
+                f"/health got {resp.status_code} — should never be rate-limited"
+            )
+
+    def test_ping_never_rate_limited(
+        self, facade_rate_limited: str
+    ) -> None:
+        base = facade_rate_limited
+        for _ in range(20):
+            resp = httpx.get(f"{base}/ping")
+            assert resp.status_code == 200, (
+                f"/ping got {resp.status_code} — should never be rate-limited"
+            )
+
+    def test_health_trailing_slash_never_rate_limited(
+        self, facade_rate_limited: str
+    ) -> None:
+        base = facade_rate_limited
+        for _ in range(20):
+            resp = httpx.get(f"{base}/health/", follow_redirects=True)
+            assert resp.status_code == 200, (
+                f"/health/ got {resp.status_code} — "
+                f"should never be rate-limited"
+            )
+
+    def test_ping_trailing_slash_never_rate_limited(
+        self, facade_rate_limited: str
+    ) -> None:
+        base = facade_rate_limited
+        for _ in range(20):
+            resp = httpx.get(f"{base}/ping/", follow_redirects=True)
+            assert resp.status_code == 200, (
+                f"/ping/ got {resp.status_code} — "
+                f"should never be rate-limited"
+            )
+
+
+@pytest.fixture(scope="module")
+def facade_register_limit() -> str:
+    """Start uvicorn with a low register limit."""
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn",
+            "a2a_mcp_bridge.facade:create_app",
+            "--host", "127.0.0.1",
+            "--port", str(_RATE_LIMIT_PORT + 2),
+            "--factory",
+        ],
+        env={
+            **os.environ,
+            "PYTHONPATH": "src",
+            "A2A_RATE_LIMIT_GLOBAL": "200",
+            "A2A_RATE_LIMIT_REGISTER": "2",
+            "A2A_RATE_LIMIT_SEND": "200",
+            "A2A_RATE_LIMIT_INBOX": "200",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    base_url = f"http://127.0.0.1:{_RATE_LIMIT_PORT + 2}"
+    deadline = time.monotonic() + 8.0
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=1.0)
+            if resp.status_code == 200:
+                break
+        except (httpx.ConnectError, httpx.ReadTimeout):
+            pass
+        time.sleep(0.15)
+    else:
+        proc.kill()
+        _out, err = proc.communicate(timeout=5)
+        pytest.fail(
+            f"Register-limit façade did not start "
+            f"on port {_RATE_LIMIT_PORT + 2}:\n"
+            f"stderr: {err.decode()}"
+        )
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@pytest.fixture(scope="module")
+def facade_global_limit() -> str:
+    """Start uvicorn with a low global limit."""
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn",
+            "a2a_mcp_bridge.facade:create_app",
+            "--host", "127.0.0.1",
+            "--port", str(_RATE_LIMIT_PORT + 3),
+            "--factory",
+        ],
+        env={
+            **os.environ,
+            "PYTHONPATH": "src",
+            "A2A_RATE_LIMIT_GLOBAL": "4",
+            "A2A_RATE_LIMIT_REGISTER": "200",
+            "A2A_RATE_LIMIT_SEND": "200",
+            "A2A_RATE_LIMIT_INBOX": "200",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    base_url = f"http://127.0.0.1:{_RATE_LIMIT_PORT + 3}"
+    deadline = time.monotonic() + 8.0
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=1.0)
+            if resp.status_code == 200:
+                break
+        except (httpx.ConnectError, httpx.ReadTimeout):
+            pass
+        time.sleep(0.15)
+    else:
+        proc.kill()
+        _out, err = proc.communicate(timeout=5)
+        pytest.fail(
+            f"Global-limit façade did not start "
+            f"on port {_RATE_LIMIT_PORT + 3}:\n"
+            f"stderr: {err.decode()}"
+        )
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+class TestRateLimitIntegrationRegister:
+    """Per-route register rate limiting."""
+
+    def test_register_limit_returns_429(
+        self, facade_register_limit: str
+    ) -> None:
+        base = facade_register_limit
+        payload = {"agent_id": "regtest"}
+
+        # First 2 should pass (A2A_RATE_LIMIT_REGISTER=2).
+        for _ in range(2):
+            resp = httpx.post(f"{base}/register", json=payload)
+            assert resp.status_code == 200, (
+                f"Expected 200, got {resp.status_code}: {resp.json()}"
+            )
+
+        # 3rd should be blocked.
+        resp = httpx.post(f"{base}/register", json=payload)
+        assert resp.status_code == 429, (
+            f"Expected 429, got {resp.status_code}: {resp.json()}"
+        )
+        data = resp.json()
+        assert data["error"]["code"] == "RATE_LIMITED"
+
+
+class TestRateLimitIntegrationGlobal:
+    """Global rate limiting."""
+
+    def test_global_limit_returns_429_on_list(
+        self, facade_global_limit: str
+    ) -> None:
+        base = facade_global_limit
+        payload = {"active_within_days": 7}
+
+        # First 4 should pass (A2A_RATE_LIMIT_GLOBAL=4).
+        for _ in range(4):
+            resp = httpx.post(f"{base}/list", json=payload)
+            assert resp.status_code == 200, (
+                f"Expected 200, got {resp.status_code}: {resp.json()}"
+            )
+
+        # 5th should be blocked by global limit.
+        resp = httpx.post(f"{base}/list", json=payload)
+        assert resp.status_code == 429, (
+            f"Expected 429, got {resp.status_code}: {resp.json()}"
+        )
+        data = resp.json()
+        assert data["error"]["code"] == "RATE_LIMITED"
+        assert resp.headers.get("Retry-After") == "60"


### PR DESCRIPTION
## Summary

Hardens the in-memory rate limiter against unbounded growth and shields
monitoring endpoints from ever returning 429.

## Motivation

The rate-limiting v0.6.2 groundwork (PR merged earlier today as `feat/facade-rate-limiting`) introduced a per-IP sliding-window counter but had no memory cap — every transient client IP added a key to the `hits` dict and never left. Over time the dict grows unboundedly on any facade exposed to the internet.

Separately, `/health` and `/ping` endpoints used by monitoring tooling would have been blocked by a flooder sharing the same source IP as the prober (rare but possible behind NAT / reverse proxies).

## Changes

### Memory guard
- `RateLimiter.prune_stale()` — evicts keys whose timestamps have all expired (> 60 s). Skips empty lists to avoid races with `defaultdict` insertion in `allow()`.
- **Dual trigger**:
  - Periodic sweep every `_PRUNE_INTERVAL_S = 60 s` — lightweight, catches slow leaks.
  - Forced sweep when `len(hits) > _MAX_HITS_KEYS = 10_000` — aggressive, prevents OOM.
- `FacadeRateLimiters.prune_stale()` aggregates across all sub-limiters.
- Lazy init of `_last_prune` (sentinel `-1.0`) avoids a spurious sweep at startup.
- Dict-size and time-elapsed triggers merged with `or` so they never fire redundantly back-to-back.

### Exemption
- `/health` and `/ping` (and their trailing-slash variants) bypass rate limiting entirely via `_should_skip_rate_limit()`.
- `for_route()` robustified with `rstrip("/")` for consistent path matching.

### Tests
| Suite | Before | After |
|---|---|---|
| `tests/test_rate_limit.py` (unit) | ~20 | **29** |
| `tests/test_rate_limit_integration.py` (new) | — | **7** |
| Full suite | 233 | **255** |

### Version
`0.6.1` → `0.6.2` in `pyproject.toml`.

## Verification

- `ruff check` — clean on all modified files.
- `pytest` — 255 passed.
- Manual runtime check with `TestClient`:
  - `POST /send` with `A2A_RATE_LIMIT_SEND=3` → `[400,400,400,429,429,429]` ✅
  - `GET /ping` ×20 under global limit saturation → all 200 ✅
  - `GET /ping/` (trailing slash) → 200 ✅

## Attribution

Initial implementation by `vlbeau-deepseek`. Two micro-fixes applied during review:
1. Lazy init of `_last_prune` to avoid spurious first-call sweep.
2. Merged redundant `if/elif` into a single `or` guard so both triggers bump `_last_prune` consistently.
