### PR TITLE
chore: remove F841/F401 lint errors left by PR #31

### DIFF
--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -234,13 +234,15 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         from .bus_store import HttpBusStore
         store: BusStore = HttpBusStore(bus_url, agent_id=agent_id, api_key=bus_api_key)
         signal_dir: SignalDir | None = None
-        waker: WebhookWaker | None = None
     else:
         sd = SignalDir(signal_dir_path or _resolve_signal_dir())
         store = Store(db_path, signal_dir=sd)
         store.init_schema()
         signal_dir = sd
-        waker = _load_waker_if_stale()
+        # Warm the module-level waker cache so the first tool call doesn't pay
+        # the registry-read cost. The return value is discarded — tool closures
+        # below call _load_waker_if_stale() directly to pick up hot reloads.
+        _load_waker_if_stale()
     store.upsert_agent(agent_id)
 
     mcp = A2AMcp("a2a-mcp-bridge")

--- a/tests/test_stale_wake_registry.py
+++ b/tests/test_stale_wake_registry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

Removes two lint errors (F841 + F401) left behind by PR #31 (`fix/stale-wake-registry`).

## Errors fixed

### 1. F841 — Unused `waker` local in `server.py::build_server()`

```python
if bus_url:
    ...
    waker: WebhookWaker | None = None   # ← never read
else:
    ...
    waker = _load_waker_if_stale()      # ← never read either
```

The tool closures defined below (`agent_send`, etc.) call `_load_waker_if_stale()` **directly** on every invocation (line 294) — the local `waker` was shadowed from the start.

**Fix:** drop both local assignments. The `else` branch keeps calling `_load_waker_if_stale()` without capturing the return value, since the side effect of warming the module-level cache at startup is still desirable. Added a comment explaining the intent.

### 2. F401 — Unused `patch` import in `test_stale_wake_registry.py`

```python
from unittest.mock import patch   # ← never used
```

The tests use `monkeypatch` (pytest fixture) exclusively.

**Fix:** remove the dead import.

## Verification

- `ruff check src/ tests/` → clean.
- `pytest` → 233 passed. No behavior change.

## Context

These were flagged during review of PR #34. Decoupled into their own PR to keep #34 focused on the rate-limit memory guard. Stacks cleanly on `main`.
