### PR TITLE
feat(v0.7.0): file transfer primitive (ADR-007 Option A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-01
+
+### Added — File Transfer Primitive (ADR-007 Option A)
+
+- **`transfers.py` — same-machine file staging primitive** — new module that
+  stages a local file under `A2A_TRANSFER_DIR` (default `~/.a2a-transfers`,
+  mode `0o700`) and returns a `TransferRecord` with sha256, size, locator
+  path, and TTL expiry. Implements atomic copy (tmp → fsync → rename), mode
+  `0o600` on staged files, path-traversal guard via `realpath`, per-agent
+  quota (`A2A_TRANSFER_MAX_PENDING_PER_AGENT`, default 50), size cap
+  (`A2A_TRANSFER_MAX_SIZE_BYTES`, default 100 MB), and TTL sweep via
+  `_transfer_sweep()`. ACL scoped to the declared sender/recipient pair.
+  See ADR-007 §4 for the frozen wire protocol.
+  ([transfers.py](src/a2a_mcp_bridge/transfers.py))
+- **Three new MCP tools — `agent_send_file`, `agent_fetch_file`,
+  `agent_delete_file`** — thin adapters wired into `server.py`:
+  - `agent_send_file(target, file_path, description?, expires_in?, intent?)`
+    stages the file and posts an ADR-007 JSON reference message (`kind:
+    "file_transfer"`, `version: 1`) to the bus. The raw file bytes never
+    enter either agent's LLM context.
+  - `agent_fetch_file(transfer_id, verify=True)` resolves the locator to
+    a local path after ACL check; re-verifies sha256 by default (~50 ms
+    per 100 MB).
+  - `agent_delete_file(transfer_id)` removes the staged directory. Scoped
+    to sender/recipient.
+  ([tools.py](src/a2a_mcp_bridge/tools.py),
+   [server.py](src/a2a_mcp_bridge/server.py))
+- **Environment variables** (all with safe defaults):
+  - `A2A_TRANSFER_DIR` — staging directory (default `~/.a2a-transfers`)
+  - `A2A_TRANSFER_MAX_SIZE_BYTES` — per-file size cap (default 100 MB)
+  - `A2A_TRANSFER_MAX_PENDING_PER_AGENT` — quota (default 50)
+  - `A2A_TRANSFER_DEFAULT_TTL_SECONDS` — default TTL (default 86400 = 24 h)
+  - `A2A_TRANSFER_MAX_TTL_SECONDS` — hard TTL cap (default 604800 = 7 d)
+
+### Known limitations (v0.7.0)
+
+- **Same-machine only.** Sender and recipient must share the filesystem
+  under `A2A_TRANSFER_DIR`. Cross-machine transfer is deferred to Option C
+  (v0.7.1 via the HTTP facade), per ADR-007 §4.
+- **TTL sweep is manual.** `_transfer_sweep()` exists but is not
+  auto-scheduled — callers must invoke it (e.g. cron, startup hook). A
+  background task in `build_server()` is tracked as a follow-up.
+
 ### Added — HTTP Facade (v0.6.0)
 
 - **`facade.py` — FastAPI HTTP façade server** — exposes the SQLite bus over

--- a/README.md
+++ b/README.md
@@ -590,6 +590,11 @@ a2a-mcp-bridge register --all --hermes-profiles ~/.hermes/profiles
 | `A2A_RATE_LIMIT_SEND` | `60` | Requests/min limit for `/send`. |
 | `A2A_RATE_LIMIT_INBOX` | `120` | Requests/min limit for `/inbox` and `/inbox_peek`. |
 | `A2A_RATE_LIMIT_REGISTER` | `10` | Requests/min limit for `/register`. |
+| `A2A_TRANSFER_DIR` | `~/.a2a-transfers` | Staging directory for file transfers (ADR-007). Created with mode 0o700 if missing. |
+| `A2A_TRANSFER_DEFAULT_TTL_SECONDS` | `86400` | Default per-transfer TTL (24 h). |
+| `A2A_TRANSFER_MAX_TTL_SECONDS` | `604800` | Hard cap on any transfer TTL (7 d). |
+| `A2A_TRANSFER_MAX_SIZE_BYTES` | `104857600` | Max file size per transfer (100 MB). |
+| `A2A_TRANSFER_MAX_PENDING_PER_AGENT` | `50` | Max un-expired transfers a single sender may have open. |
 
 ## HTTP Facade (Remote Mode)
 
@@ -698,6 +703,30 @@ Rate limits are configured via environment variables (requests/minute):
 
 Set `A2A_RATE_LIMIT_GLOBAL=0` to disable rate limiting entirely (useful for
 development or when behind a reverse proxy that already handles it).
+
+### File transfers (ADR-007)
+
+Starting v0.7.0, agents can hand off arbitrary-size files without
+loading their contents into either LLM's context window.
+
+```python
+# sender
+agent_send_file(target="bob", file_path="/tmp/report.md", description="weekly")
+# → {"transfer_id": "...", "sha256": "...", "size": 28845, ...}
+
+# recipient (after the wake-up fires)
+inbox = agent_inbox()                           # gets the reference
+ref = json.loads(inbox[0]["body"])              # kind=file_transfer
+got = agent_fetch_file(ref["transfer_id"])
+# → {"path": "/home/vince/.a2a-transfers/<uuid>/<sha>_report.md", ...}
+
+# recipient reads the file with its own read_file tool, then:
+agent_delete_file(ref["transfer_id"])
+```
+
+Option A ships **same-machine only** — both sender and recipient
+must share the filesystem under `A2A_TRANSFER_DIR`. Cross-machine
+transfer via the HTTP façade lands in v0.7.1 (Option C).
 
 ### `HttpBusStore` client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.6.2"
+version = "0.7.0"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/__init__.py
+++ b/src/a2a_mcp_bridge/__init__.py
@@ -1,3 +1,3 @@
 """a2a-mcp-bridge — MCP server for agent-to-agent messaging."""
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -20,10 +20,13 @@ from .bus_store import BusStore
 from .signals import SignalDir
 from .store import Store
 from .tools import (
+    tool_agent_delete_file,
+    tool_agent_fetch_file,
     tool_agent_inbox,
     tool_agent_inbox_peek,
     tool_agent_list,
     tool_agent_send,
+    tool_agent_send_file,
     tool_agent_subscribe,
 )
 from .wake import WebhookWaker, load_registry
@@ -468,6 +471,55 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             "version": _bridge_version(),
             "agent_id": agent_id,
         }
+
+    @mcp.tool()
+    def agent_send_file(
+        target: str,
+        file_path: str,
+        description: str = "",
+        expires_in: int | None = None,
+        intent: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a local file to *target* without loading it into LLM context.
+
+        See ADR-007 for the full protocol. The file is staged under
+        ``A2A_TRANSFER_DIR`` and a JSON reference is sent over the A2A
+        message bus. Recipient fetches via :func:`agent_fetch_file`.
+
+        Args:
+            target: recipient agent_id.
+            file_path: absolute path to a local file.
+            description: optional human-readable note.
+            expires_in: seconds until TTL expiry (default 86400, hard
+                cap A2A_TRANSFER_MAX_TTL_SECONDS).
+            intent: ADR-002 wake intent (triage / execute / review /
+                question / fyi).
+
+        Returns:
+            ``{"transfer_id", "sha256", "size", "filename", "expires_at",
+            "message_id"}`` on success, ``{"error": {"code", "message"}}``
+            otherwise.
+        """
+        return tool_agent_send_file(
+            store, agent_id, target, file_path,
+            description=description, expires_in=expires_in,
+            signal_dir=signal_dir, waker=_load_waker_if_stale(), intent=intent,
+        )
+
+    @mcp.tool()
+    def agent_fetch_file(transfer_id: str, verify: bool = True) -> dict[str, Any]:
+        """Resolve *transfer_id* to a local path for this agent.
+
+        Caller must be the declared recipient (or sender). When
+        ``verify=True`` (default), sha256 is re-checked — ~50 ms per
+        100 MB, negligible vs. silent-corruption risk.
+        """
+        return tool_agent_fetch_file(store, agent_id, transfer_id, verify=verify)
+
+    @mcp.tool()
+    def agent_delete_file(transfer_id: str) -> dict[str, Any]:
+        """Delete a staged transfer. Caller must be sender or recipient."""
+        return tool_agent_delete_file(store, agent_id, transfer_id)
 
     return mcp
 

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -11,6 +11,12 @@ from .intents import DEFAULT_INTENT, normalize_intent, wakes
 from .logging_ext import hash_body, log_event
 from .models import Message
 from .signals import SignalDir
+from .transfers import (
+    delete_transfer,
+    load_manifest,
+    resolve_locator_path,
+    stage_file,
+)
 from .wake import WebhookWaker
 
 logger = logging.getLogger("a2a_mcp_bridge.tools")
@@ -299,3 +305,145 @@ def _serialize_message(m: Message) -> dict[str, Any]:
         "sender_session_id": m.sender_session_id,
         "intent": getattr(m, "intent", DEFAULT_INTENT),
     }
+
+
+def tool_agent_send_file(
+    store: BusStore,
+    caller_id: str,
+    target: str,
+    file_path: str,
+    description: str = "",
+    expires_in: int | None = None,
+    signal_dir: SignalDir | None = None,
+    waker: WebhookWaker | None = None,
+    intent: str | None = None,
+) -> dict[str, Any]:
+    """Stage a local file and send its reference to *target* via A2A.
+
+    Wire protocol: ADR-007 §4.1. The file content never enters either
+    LLM's context window — only the reference message does.
+
+    Errors returned as ``{"error": {"code": ..., "message": ...}}``:
+        TRANSFER_SOURCE_NOT_FOUND, TRANSFER_TOO_LARGE,
+        TRANSFER_QUOTA_EXCEEDED, <delegated from agent_send>.
+    """
+    from pathlib import Path as _Path
+
+    src = _Path(file_path)
+    filename = src.name
+
+    try:
+        rec = stage_file(
+            src,
+            sender_id=caller_id,
+            recipient_id=target,
+            filename=filename,
+            description=description,
+            expires_in=expires_in,
+        )
+    except FileNotFoundError:
+        return {"error": {"code": "TRANSFER_SOURCE_NOT_FOUND", "message": str(src)}}
+    except ValueError as e:
+        code, _, msg = str(e).partition(":")
+        return {"error": {"code": code.strip(), "message": msg.strip()}}
+
+    # Build ADR-007 body. expires_at in manifest is epoch; serialise as ISO.
+    manifest = load_manifest(rec.transfer_id)
+    body_obj = {
+        "kind": "file_transfer",
+        "version": 1,
+        "transfer_id": rec.transfer_id,
+        "filename": rec.filename,
+        "size": rec.size,
+        "sha256": rec.sha256,
+        "description": description,
+        "expires_at": _iso_utc(manifest["expires_at"]),
+        "locator": {"scheme": "file", "path": rec.locator_path},
+    }
+    import json as _json
+
+    send_result = tool_agent_send(
+        store, caller_id, target, _json.dumps(body_obj),
+        metadata=None,
+        signal_dir=signal_dir,
+        waker=waker,
+        intent=intent,
+    )
+    if "error" in send_result:
+        # The file is staged but the message failed — surface both.
+        return {
+            "error": send_result["error"],
+            "transfer_id": rec.transfer_id,
+            "hint": "file staged but notification failed; caller may retry agent_send",
+        }
+    return {
+        "transfer_id": rec.transfer_id,
+        "sha256": rec.sha256,
+        "size": rec.size,
+        "filename": rec.filename,
+        "expires_at": body_obj["expires_at"],
+        "message_id": send_result.get("message_id"),
+    }
+
+
+def tool_agent_fetch_file(
+    store: BusStore,
+    caller_id: str,
+    transfer_id: str,
+    verify: bool = True,
+) -> dict[str, Any]:
+    """Resolve *transfer_id* to a local path for the caller.
+
+    The path is returned verbatim — the LLM tool that actually reads
+    the bytes (e.g. ``read_file``) is invoked separately. Validates
+    sha256 by default (cost ~50 ms per 100 MB).
+    """
+    try:
+        path = resolve_locator_path(transfer_id, caller_id=caller_id)
+        m = load_manifest(transfer_id)
+    except FileNotFoundError:
+        return {"error": {"code": "TRANSFER_NOT_FOUND", "message": transfer_id}}
+    except PermissionError as e:
+        return {"error": {"code": "TRANSFER_ACL_DENIED", "message": str(e)}}
+
+    if verify:
+        import hashlib as _h
+
+        h = _h.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(64 * 1024), b""):
+                h.update(chunk)
+        if h.hexdigest() != m["sha256"]:
+            return {"error": {"code": "TRANSFER_HASH_MISMATCH", "message": transfer_id}}
+
+    return {
+        "transfer_id": transfer_id,
+        "path": str(path),
+        "size": m["size"],
+        "sha256": m["sha256"],
+        "filename": m["filename"],
+        "description": m.get("description", ""),
+        "expires_at": _iso_utc(m["expires_at"]),
+    }
+
+
+def tool_agent_delete_file(
+    store: BusStore,
+    caller_id: str,
+    transfer_id: str,
+) -> dict[str, Any]:
+    """Explicit deletion. Caller must be sender or recipient."""
+    try:
+        delete_transfer(transfer_id, caller_id=caller_id)
+    except FileNotFoundError:
+        return {"error": {"code": "TRANSFER_NOT_FOUND", "message": transfer_id}}
+    except PermissionError as e:
+        return {"error": {"code": "TRANSFER_ACL_DENIED", "message": str(e)}}
+    return {"deleted": True, "transfer_id": transfer_id}
+
+
+def _iso_utc(epoch: float) -> str:
+    """Return ``epoch`` as ISO-8601 Z string."""
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(epoch, UTC).isoformat().replace("+00:00", "Z")

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -7,6 +7,7 @@ frozen by that ADR — do not change without amending it.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import uuid
@@ -86,11 +87,14 @@ class TransferRecord:
     """Immutable record of a staged transfer (returned by stage_file)."""
     transfer_id: str
     sender_id: str
+    recipient_id: str
     filename: str
     size: int
     sha256: str
     locator_path: str   # absolute path, scheme=file
+    description: str
     created_at: float   # time.time() (wall clock, for expiry math)
+    expires_at: float   # epoch seconds
 
 
 def _hash_and_copy(src: Path, dest: Path) -> tuple[str, int]:
@@ -117,13 +121,47 @@ def _hash_and_copy(src: Path, dest: Path) -> tuple[str, int]:
     return h.hexdigest(), size
 
 
-def stage_file(source: Path, *, sender_id: str, filename: str) -> TransferRecord:
+def _count_pending_for_sender(sender_id: str) -> int:
+    """Count un-expired transfers owned by *sender_id*."""
+    import time as _time
+
+    base = resolve_transfer_dir()
+    now = _time.time()
+    count = 0
+    if not base.is_dir():
+        return 0
+    for child in base.iterdir():
+        if not child.is_dir():
+            continue
+        meta_path = child / "meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            m = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if m.get("sender_id") == sender_id and float(m.get("expires_at", 0.0)) > now:
+            count += 1
+    return count
+
+
+def stage_file(
+    source: Path,
+    *,
+    sender_id: str,
+    recipient_id: str,
+    filename: str,
+    description: str = "",
+    expires_in: int | None = None,
+) -> TransferRecord:
     """Copy *source* into the staging dir and return a :class:`TransferRecord`.
 
     Raises:
         FileNotFoundError: if *source* does not exist.
         ValueError: ``TRANSFER_TOO_LARGE: ...`` if the file exceeds
             ``A2A_TRANSFER_MAX_SIZE_BYTES``.
+        ValueError: ``TRANSFER_QUOTA_EXCEEDED: ...`` if the sender has
+            too many pending transfers.
     """
     import time as _time
 
@@ -137,7 +175,23 @@ def stage_file(source: Path, *, sender_id: str, filename: str) -> TransferRecord
             f"TRANSFER_TOO_LARGE: {src_size} bytes exceeds limit {max_size}"
         )
 
+    # Quota check before staging
+    max_pending = _env_int("A2A_TRANSFER_MAX_PENDING_PER_AGENT", _DEFAULT_MAX_PENDING_PER_AGENT)
+    pending = _count_pending_for_sender(sender_id)
+    if pending >= max_pending:
+        raise ValueError(
+            f"TRANSFER_QUOTA_EXCEEDED: {pending} pending transfers for {sender_id}, limit {max_pending}"
+        )
+
     tid = new_transfer_id()
+    rec_created_at = _time.time()
+
+    # TTL clamping: min(ttl, max_ttl), no lower bound (negative = already expired, useful for tests)
+    ttl = expires_in if expires_in is not None else _env_int("A2A_TRANSFER_DEFAULT_TTL_SECONDS", _DEFAULT_TTL_SECONDS)
+    max_ttl = _env_int("A2A_TRANSFER_MAX_TTL_SECONDS", _DEFAULT_MAX_TTL_SECONDS)
+    ttl = min(ttl, max_ttl)
+    expires_at = rec_created_at + ttl
+
     # Stage with a first pass to get sha256, then rename to canonical name.
     # Two-step because the canonical filename includes sha256[:16].
     staging_tmp = resolve_transfer_dir() / tid / f".staging_{filename}"
@@ -145,12 +199,34 @@ def stage_file(source: Path, *, sender_id: str, filename: str) -> TransferRecord
     final = transfer_path(tid, sha, filename)
     os.rename(staging_tmp, final)
 
+    # Write meta.json atomically
+    manifest = {
+        "transfer_id": tid,
+        "sender_id": sender_id,
+        "recipient_id": recipient_id,
+        "filename": filename,
+        "size": actual_size,
+        "sha256": sha,
+        "description": description,
+        "created_at": rec_created_at,
+        "expires_at": expires_at,
+        "locator": {"scheme": "file", "path": str(final)},
+        "version": 1,
+    }
+    meta_dir = resolve_transfer_dir() / tid
+    meta_tmp = meta_dir / "meta.json.tmp"
+    meta_tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    os.rename(meta_tmp, meta_dir / "meta.json")
+
     return TransferRecord(
         transfer_id=tid,
         sender_id=sender_id,
+        recipient_id=recipient_id,
         filename=filename,
         size=actual_size,
         sha256=sha,
         locator_path=str(final),
-        created_at=_time.time(),
+        description=description,
+        created_at=rec_created_at,
+        expires_at=expires_at,
     )

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -267,3 +267,55 @@ def resolve_locator_path(transfer_id: str, *, caller_id: str) -> Path:
     if not is_safe_path(path):
         raise ValueError(f"TRANSFER_UNSAFE_PATH: {path}")
     return path
+
+
+def delete_transfer(transfer_id: str, *, caller_id: str) -> None:
+    """Delete a staged transfer + manifest. Scoped to sender or recipient.
+
+    Raises:
+        FileNotFoundError: unknown transfer_id.
+        PermissionError: caller is neither sender nor recipient.
+    """
+    import shutil
+
+    m = load_manifest(transfer_id)  # raises FileNotFoundError
+    if caller_id not in (m.get("sender_id"), m.get("recipient_id")):
+        raise PermissionError(f"TRANSFER_ACL_DENIED: {caller_id} cannot delete {transfer_id}")
+    directory = resolve_transfer_dir() / transfer_id
+    if is_safe_path(directory):
+        shutil.rmtree(directory, ignore_errors=False)
+
+
+def _transfer_sweep() -> int:
+    """Delete every transfer whose manifest says it's expired.
+
+    Returns:
+        Number of transfers deleted.
+    """
+    import shutil
+    import time as _time
+
+    base = resolve_transfer_dir()
+    now = _time.time()
+    removed = 0
+    if not base.is_dir():
+        return 0
+    for child in base.iterdir():
+        if not child.is_dir():
+            continue
+        meta_path = child / "meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            m = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning("transfer_sweep: corrupt manifest at %s, removing", child)
+            shutil.rmtree(child, ignore_errors=True)
+            removed += 1
+            continue
+        if float(m.get("expires_at", 0.0)) <= now:
+            shutil.rmtree(child, ignore_errors=True)
+            removed += 1
+    if removed:
+        logger.info("transfer_sweep removed %d expired transfer(s)", removed)
+    return removed

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -46,3 +47,33 @@ def resolve_transfer_dir() -> Path:
     path = Path(override) if override else Path.home() / ".a2a-transfers"
     path.mkdir(mode=0o700, parents=True, exist_ok=True)
     return path
+
+
+def new_transfer_id() -> str:
+    """Return a fresh UUID4 string."""
+    return str(uuid.uuid4())
+
+
+def transfer_path(transfer_id: str, sha256_hex: str, filename: str) -> Path:
+    """Return the canonical on-disk path for a transfer.
+
+    Layout: ``<transfer_dir>/<transfer_id>/<sha256[:16]>_<filename>``.
+    The caller is responsible for creating the parent directory.
+    """
+    base = resolve_transfer_dir()
+    return base / transfer_id / f"{sha256_hex[:16]}_{filename}"
+
+
+def is_safe_path(candidate: Path) -> bool:
+    """Return True iff *candidate*'s realpath lives under the transfer dir.
+
+    Defends against path-traversal (``../../etc/passwd``) and symlink
+    escapes. Both sides of the check are resolved via :func:`os.path.realpath`.
+    """
+    base = os.path.realpath(resolve_transfer_dir())
+    try:
+        real = os.path.realpath(candidate)
+    except OSError:
+        return False
+    base_sep = base if base.endswith(os.sep) else base + os.sep
+    return real == base or real.startswith(base_sep)

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -1,0 +1,48 @@
+"""File transfer primitive (ADR-007 Option A) — same-machine staging dir.
+
+Implements the ``agent_send_file`` / ``agent_fetch_file`` / ``agent_delete_file``
+flow described in ADR-007 §4. Wire protocol and security model are
+frozen by that ADR — do not change without amending it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default limits — can be overridden via env (see _env_int below).
+_DEFAULT_TTL_SECONDS = 86_400           # 24 h
+_DEFAULT_MAX_TTL_SECONDS = 604_800      # 7 d
+_DEFAULT_MAX_SIZE_BYTES = 100 * 1024 * 1024  # 100 MB
+_DEFAULT_MAX_PENDING_PER_AGENT = 50
+_SWEEP_INTERVAL_S = 300.0                # 5 min
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer env var with graceful fallback (pattern from rate_limit.py)."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer, using default %d", name, raw, default)
+        return default
+
+
+def resolve_transfer_dir() -> Path:
+    """Return the staging directory, creating it with mode 0o700 if missing.
+
+    Resolution order:
+      1. ``A2A_TRANSFER_DIR`` env var (absolute path).
+      2. ``$HOME/.a2a-transfers``.
+
+    Mirrors the pattern used by :mod:`a2a_mcp_bridge.signals` for
+    ``A2A_SIGNAL_DIR``.
+    """
+    override = os.environ.get("A2A_TRANSFER_DIR", "").strip()
+    path = Path(override) if override else Path.home() / ".a2a-transfers"
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return path

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -230,3 +230,40 @@ def stage_file(
         created_at=rec_created_at,
         expires_at=expires_at,
     )
+
+
+def load_manifest(transfer_id: str) -> dict:
+    """Return the parsed meta.json for *transfer_id*.
+
+    Raises:
+        FileNotFoundError: transfer_id unknown.
+        ValueError: manifest JSON malformed.
+    """
+    base = resolve_transfer_dir()
+    meta_path = base / transfer_id / "meta.json"
+    if not meta_path.is_file():
+        raise FileNotFoundError(transfer_id)
+    try:
+        return json.loads(meta_path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"TRANSFER_MANIFEST_CORRUPT: {e}") from e
+
+
+def resolve_locator_path(transfer_id: str, *, caller_id: str) -> Path:
+    """Return the on-disk path for *transfer_id* after ACL check.
+
+    Only the sender or recipient declared in the manifest may resolve.
+    The returned path is also re-checked with :func:`is_safe_path`.
+
+    Raises:
+        FileNotFoundError: unknown transfer_id.
+        PermissionError: caller is neither sender nor recipient.
+        ValueError: locator path escapes the transfer dir (corrupt manifest).
+    """
+    m = load_manifest(transfer_id)
+    if caller_id not in (m.get("sender_id"), m.get("recipient_id")):
+        raise PermissionError(f"TRANSFER_ACL_DENIED: {caller_id} not authorised for {transfer_id}")
+    path = Path(m["locator"]["path"])
+    if not is_safe_path(path):
+        raise ValueError(f"TRANSFER_UNSAFE_PATH: {path}")
+    return path

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -6,9 +6,11 @@ frozen by that ADR — do not change without amending it.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -77,3 +79,78 @@ def is_safe_path(candidate: Path) -> bool:
         return False
     base_sep = base if base.endswith(os.sep) else base + os.sep
     return real == base or real.startswith(base_sep)
+
+
+@dataclass(frozen=True)
+class TransferRecord:
+    """Immutable record of a staged transfer (returned by stage_file)."""
+    transfer_id: str
+    sender_id: str
+    filename: str
+    size: int
+    sha256: str
+    locator_path: str   # absolute path, scheme=file
+    created_at: float   # time.time() (wall clock, for expiry math)
+
+
+def _hash_and_copy(src: Path, dest: Path) -> tuple[str, int]:
+    """Copy *src* to *dest* (atomic rename) while computing sha256 + size.
+
+    Writes to ``<dest>.tmp`` then renames. Flushes and fsyncs before rename.
+    Creates parent dirs with mode 0o700, the staged file with mode 0o600.
+    """
+    dest.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp = dest.parent / f".tmp.{dest.name}"
+    h = hashlib.sha256()
+    size = 0
+    with open(src, "rb") as fin, open(os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600), "wb") as fout:
+        while True:
+            chunk = fin.read(64 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+            size += len(chunk)
+            fout.write(chunk)
+        fout.flush()
+        os.fsync(fout.fileno())
+    os.rename(tmp, dest)
+    return h.hexdigest(), size
+
+
+def stage_file(source: Path, *, sender_id: str, filename: str) -> TransferRecord:
+    """Copy *source* into the staging dir and return a :class:`TransferRecord`.
+
+    Raises:
+        FileNotFoundError: if *source* does not exist.
+        ValueError: ``TRANSFER_TOO_LARGE: ...`` if the file exceeds
+            ``A2A_TRANSFER_MAX_SIZE_BYTES``.
+    """
+    import time as _time
+
+    if not source.is_file():
+        raise FileNotFoundError(source)
+
+    max_size = _env_int("A2A_TRANSFER_MAX_SIZE_BYTES", _DEFAULT_MAX_SIZE_BYTES)
+    src_size = source.stat().st_size
+    if src_size > max_size:
+        raise ValueError(
+            f"TRANSFER_TOO_LARGE: {src_size} bytes exceeds limit {max_size}"
+        )
+
+    tid = new_transfer_id()
+    # Stage with a first pass to get sha256, then rename to canonical name.
+    # Two-step because the canonical filename includes sha256[:16].
+    staging_tmp = resolve_transfer_dir() / tid / f".staging_{filename}"
+    sha, actual_size = _hash_and_copy(source, staging_tmp)
+    final = transfer_path(tid, sha, filename)
+    os.rename(staging_tmp, final)
+
+    return TransferRecord(
+        transfer_id=tid,
+        sender_id=sender_id,
+        filename=filename,
+        size=actual_size,
+        sha256=sha,
+        locator_path=str(final),
+        created_at=_time.time(),
+    )

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -13,6 +13,7 @@ import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +233,7 @@ def stage_file(
     )
 
 
-def load_manifest(transfer_id: str) -> dict:
+def load_manifest(transfer_id: str) -> dict[str, Any]:
     """Return the parsed meta.json for *transfer_id*.
 
     Raises:
@@ -244,7 +245,8 @@ def load_manifest(transfer_id: str) -> dict:
     if not meta_path.is_file():
         raise FileNotFoundError(transfer_id)
     try:
-        return json.loads(meta_path.read_text())
+        data: dict[str, Any] = json.loads(meta_path.read_text())
+        return data
     except json.JSONDecodeError as e:
         raise ValueError(f"TRANSFER_MANIFEST_CORRUPT: {e}") from e
 

--- a/tests/test_tool_transfers.py
+++ b/tests/test_tool_transfers.py
@@ -1,0 +1,75 @@
+"""Tests for tool_agent_send_file / fetch_file / delete_file."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.store import Store
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Store:
+    s = Store(str(tmp_path / "bus.db"))
+    s.init_schema()
+    s.upsert_agent("alice")
+    s.upsert_agent("bob")
+    return s
+
+
+def test_tool_agent_send_file_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, store: Store) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path / "xfer"))
+    src = tmp_path / "report.md"
+    src.write_text("# Report\n" * 100)
+
+    from a2a_mcp_bridge.tools import tool_agent_send_file
+
+    result = tool_agent_send_file(
+        store, caller_id="alice", target="bob",
+        file_path=str(src), description="weekly report",
+    )
+    assert "error" not in result
+    assert result["transfer_id"]
+    assert result["size"] > 0
+    assert result["sha256"]
+
+    # Inbox message body is the ADR-007 JSON
+    msgs = store.read_inbox("bob")
+    assert len(msgs) == 1
+    body = json.loads(msgs[0].body)
+    assert body["kind"] == "file_transfer"
+    assert body["version"] == 1
+    assert body["transfer_id"] == result["transfer_id"]
+    assert body["locator"]["scheme"] == "file"
+
+
+def test_tool_agent_fetch_file_returns_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, store: Store) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path / "xfer"))
+    src = tmp_path / "r.md"
+    src.write_text("hello")
+
+    from a2a_mcp_bridge.tools import tool_agent_fetch_file, tool_agent_send_file
+
+    sent = tool_agent_send_file(store, caller_id="alice", target="bob", file_path=str(src))
+    got = tool_agent_fetch_file(store, caller_id="bob", transfer_id=sent["transfer_id"])
+    assert got["filename"] == "r.md"
+    assert Path(got["path"]).read_text() == "hello"
+
+
+def test_tool_agent_delete_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, store: Store) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path / "xfer"))
+    src = tmp_path / "r.md"
+    src.write_text("hi")
+
+    from a2a_mcp_bridge.tools import (
+        tool_agent_delete_file,
+        tool_agent_fetch_file,
+        tool_agent_send_file,
+    )
+
+    sent = tool_agent_send_file(store, caller_id="alice", target="bob", file_path=str(src))
+    tool_agent_delete_file(store, caller_id="bob", transfer_id=sent["transfer_id"])
+
+    res = tool_agent_fetch_file(store, caller_id="bob", transfer_id=sent["transfer_id"])
+    assert "error" in res

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -126,3 +126,42 @@ def test_stage_file_quota_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     stage_file(src, sender_id="alice", filename="b.md", recipient_id="bob")
     with pytest.raises(ValueError, match="TRANSFER_QUOTA_EXCEEDED"):
         stage_file(src, sender_id="alice", filename="c.md", recipient_id="bob")
+
+
+def test_load_manifest_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "s.md"
+    src.write_text("data")
+
+    from a2a_mcp_bridge.transfers import load_manifest, stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="s.md", recipient_id="bob")
+    m = load_manifest(rec.transfer_id)
+    assert m["sender_id"] == "alice"
+    assert m["recipient_id"] == "bob"
+    assert m["sha256"] == rec.sha256
+
+
+def test_resolve_locator_path_enforces_acl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "s.md"
+    src.write_text("secret")
+
+    from a2a_mcp_bridge.transfers import resolve_locator_path, stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="s.md", recipient_id="bob")
+    # Recipient can fetch
+    assert resolve_locator_path(rec.transfer_id, caller_id="bob") == Path(rec.locator_path)
+    # Sender can fetch (useful for resend/verify)
+    assert resolve_locator_path(rec.transfer_id, caller_id="alice") == Path(rec.locator_path)
+    # Random third party cannot
+    with pytest.raises(PermissionError):
+        resolve_locator_path(rec.transfer_id, caller_id="eve")
+
+
+def test_resolve_locator_path_unknown_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    from a2a_mcp_bridge.transfers import resolve_locator_path
+
+    with pytest.raises(FileNotFoundError):
+        resolve_locator_path("nonexistent", caller_id="alice")

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -65,7 +65,7 @@ def test_stage_file_creates_staged_copy(tmp_path: Path, monkeypatch: pytest.Monk
 
     from a2a_mcp_bridge.transfers import stage_file
 
-    rec = stage_file(src, sender_id="alice", filename="source.md")
+    rec = stage_file(src, sender_id="alice", recipient_id="bob", filename="source.md")
     assert rec.size == len(b"hello world\n")
     assert rec.filename == "source.md"
     assert Path(rec.locator_path).is_file()
@@ -84,7 +84,7 @@ def test_stage_file_rejects_too_large(tmp_path: Path, monkeypatch: pytest.Monkey
     from a2a_mcp_bridge.transfers import stage_file
 
     with pytest.raises(ValueError, match="TRANSFER_TOO_LARGE"):
-        stage_file(src, sender_id="alice", filename="big.bin")
+        stage_file(src, sender_id="alice", recipient_id="bob", filename="big.bin")
 
 
 def test_stage_file_rejects_source_outside_fs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,4 +92,37 @@ def test_stage_file_rejects_source_outside_fs(tmp_path: Path, monkeypatch: pytes
     from a2a_mcp_bridge.transfers import stage_file
 
     with pytest.raises(FileNotFoundError):
-        stage_file(tmp_path / "ghost.md", sender_id="alice", filename="ghost.md")
+        stage_file(tmp_path / "ghost.md", sender_id="alice", recipient_id="bob", filename="ghost.md")
+
+
+def test_stage_file_writes_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "source.md"
+    src.write_text("hi")
+
+    from a2a_mcp_bridge.transfers import stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="source.md", recipient_id="bob", description="test")
+    meta_path = Path(rec.locator_path).parent / "meta.json"
+    assert meta_path.is_file()
+    meta = json.loads(meta_path.read_text())
+    assert meta["sender_id"] == "alice"
+    assert meta["recipient_id"] == "bob"
+    assert meta["description"] == "test"
+    assert meta["sha256"] == rec.sha256
+
+
+def test_stage_file_quota_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    monkeypatch.setenv("A2A_TRANSFER_MAX_PENDING_PER_AGENT", "2")
+
+    from a2a_mcp_bridge.transfers import stage_file
+
+    src = tmp_path / "src.md"
+    src.write_text("x")
+    stage_file(src, sender_id="alice", filename="a.md", recipient_id="bob")
+    stage_file(src, sender_id="alice", filename="b.md", recipient_id="bob")
+    with pytest.raises(ValueError, match="TRANSFER_QUOTA_EXCEEDED"):
+        stage_file(src, sender_id="alice", filename="c.md", recipient_id="bob")

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -56,3 +56,40 @@ def test_is_safe_path_rejects_traversal(tmp_path: Path, monkeypatch: pytest.Monk
     assert is_safe_path(tmp_path / "abc" / "file.md") is True
     assert is_safe_path(Path("/etc/passwd")) is False
     assert is_safe_path(tmp_path / ".." / "file.md") is False  # normalises up
+
+
+def test_stage_file_creates_staged_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "source.md"
+    src.write_text("hello world\n")
+
+    from a2a_mcp_bridge.transfers import stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="source.md")
+    assert rec.size == len(b"hello world\n")
+    assert rec.filename == "source.md"
+    assert Path(rec.locator_path).is_file()
+    assert Path(rec.locator_path).read_bytes() == b"hello world\n"
+    # File mode 0o600
+    assert oct(Path(rec.locator_path).stat().st_mode)[-3:] == "600"
+
+
+def test_stage_file_rejects_too_large(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    monkeypatch.setenv("A2A_TRANSFER_MAX_SIZE_BYTES", "10")
+
+    src = tmp_path / "big.bin"
+    src.write_bytes(b"x" * 100)
+
+    from a2a_mcp_bridge.transfers import stage_file
+
+    with pytest.raises(ValueError, match="TRANSFER_TOO_LARGE"):
+        stage_file(src, sender_id="alice", filename="big.bin")
+
+
+def test_stage_file_rejects_source_outside_fs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    from a2a_mcp_bridge.transfers import stage_file
+
+    with pytest.raises(FileNotFoundError):
+        stage_file(tmp_path / "ghost.md", sender_id="alice", filename="ghost.md")

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -165,3 +165,51 @@ def test_resolve_locator_path_unknown_id(tmp_path: Path, monkeypatch: pytest.Mon
 
     with pytest.raises(FileNotFoundError):
         resolve_locator_path("nonexistent", caller_id="alice")
+
+
+def test_delete_transfer_scoped_to_parties(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "s.md"
+    src.write_text("bye")
+
+    from a2a_mcp_bridge.transfers import delete_transfer, stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="s.md", recipient_id="bob")
+
+    # Eve can't delete
+    with pytest.raises(PermissionError):
+        delete_transfer(rec.transfer_id, caller_id="eve")
+    assert Path(rec.locator_path).is_file()
+
+    # Bob can (recipient)
+    delete_transfer(rec.transfer_id, caller_id="bob")
+    assert not Path(rec.locator_path).exists()
+    assert not (tmp_path / rec.transfer_id).exists()
+
+
+def test_sweep_removes_expired(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "s.md"
+    src.write_text("data")
+
+    from a2a_mcp_bridge.transfers import _transfer_sweep, stage_file
+
+    # TTL in the past
+    rec = stage_file(src, sender_id="alice", filename="s.md", recipient_id="bob", expires_in=-1)
+    assert Path(rec.locator_path).is_file()
+
+    removed = _transfer_sweep()
+    assert removed == 1
+    assert not Path(rec.locator_path).exists()
+
+
+def test_sweep_keeps_fresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    src = tmp_path / "s.md"
+    src.write_text("data")
+
+    from a2a_mcp_bridge.transfers import _transfer_sweep, stage_file
+
+    rec = stage_file(src, sender_id="alice", filename="s.md", recipient_id="bob", expires_in=3600)
+    assert _transfer_sweep() == 0
+    assert Path(rec.locator_path).is_file()

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,0 +1,29 @@
+"""Tests for transfers.py — ADR-007 Option A (same-machine file transfer)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_resolve_transfer_dir_defaults_to_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("A2A_TRANSFER_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from a2a_mcp_bridge.transfers import resolve_transfer_dir
+
+    result = resolve_transfer_dir()
+    assert result == tmp_path / ".a2a-transfers"
+    assert result.is_dir()
+    assert oct(result.stat().st_mode)[-3:] == "700"
+
+
+def test_resolve_transfer_dir_honours_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "custom"
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(target))
+
+    from a2a_mcp_bridge.transfers import resolve_transfer_dir
+
+    result = resolve_transfer_dir()
+    assert result == target
+    assert result.is_dir()

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -27,3 +27,32 @@ def test_resolve_transfer_dir_honours_env(tmp_path: Path, monkeypatch: pytest.Mo
     result = resolve_transfer_dir()
     assert result == target
     assert result.is_dir()
+
+
+def test_new_transfer_id_is_uuid4(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    import uuid as _uuid
+
+    from a2a_mcp_bridge.transfers import new_transfer_id
+
+    tid = new_transfer_id()
+    assert _uuid.UUID(tid).version == 4
+
+
+def test_transfer_path_includes_sha_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    from a2a_mcp_bridge.transfers import transfer_path
+
+    p = transfer_path("11111111-2222-3333-4444-555555555555", "abcdef0123456789" + "0" * 48, "report.md")
+    assert p.name == "abcdef0123456789_report.md"
+    assert p.parent.name == "11111111-2222-3333-4444-555555555555"
+    assert p.parent.parent == tmp_path
+
+
+def test_is_safe_path_rejects_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+    from a2a_mcp_bridge.transfers import is_safe_path
+
+    assert is_safe_path(tmp_path / "abc" / "file.md") is True
+    assert is_safe_path(Path("/etc/passwd")) is False
+    assert is_safe_path(tmp_path / ".." / "file.md") is False  # normalises up


### PR DESCRIPTION
## Summary

Implements **ADR-007 Option A** — same-machine file transfer primitive between agents on the A2A bus, resolving issue #33.

Agents can now exchange files (up to 100 MB by default) without loading them into their LLM context. The file is staged under `A2A_TRANSFER_DIR`, a JSON reference is sent over the bus, and the recipient resolves the transfer to a local path that it can read directly.

## What changed

- **`src/a2a_mcp_bridge/transfers.py` (new, 322 LOC)** — core staging primitive: `stage_file`, `load_manifest`, `resolve_locator_path`, `delete_transfer`, `_transfer_sweep`. Atomic copy (tmp → fsync → rename), sha256 streaming, mode 0o600, path-traversal guard via `realpath`, per-agent quota, TTL clamping.
- **`src/a2a_mcp_bridge/tools.py` (+148 LOC)** — `tool_agent_send_file`, `tool_agent_fetch_file`, `tool_agent_delete_file`. Thin adapters that build the ADR-007 §4.1 JSON wire protocol and delegate to `tool_agent_send` for bus delivery.
- **`src/a2a_mcp_bridge/server.py` (+52 LOC)** — three new `@mcp.tool()` registrations.
- **`README.md`** — usage section "File transfers (ADR-007)" + env-var table update.
- **`CHANGELOG.md`** — [0.7.0] entry, features + known limitations.
- **`pyproject.toml` + `__init__.py`** — version bump 0.6.2 → 0.7.0.

## Tests

**19 new tests**, all green alongside the existing suite (274/274 pass):

- `tests/test_transfers.py` — 16 unit tests: dir resolution, uuid4 ids, path safety, stage_file happy path + size cap + quota + manifest, ACL (sender/recipient/third-party), delete, sweep.
- `tests/test_tool_transfers.py` — 3 integration tests: end-to-end send → inbox read → fetch → delete via the tool layer.

```
$ uv run ruff check src tests && uv run pytest -q && uv run mypy src/a2a_mcp_bridge/transfers.py src/a2a_mcp_bridge/tools.py
All checks passed!
274 passed
Success: no issues found in 2 source files
```

## Contract verification (plan → implementation)

| Guardrail | Code | Test |
|---|---|---|
| Transfer dir with 0o700 mode | `transfers.py:39-52` | `test_resolve_transfer_dir_defaults_to_home` |
| Path-traversal blocked | `transfers.py:70-82` | `test_is_safe_path_rejects_traversal` |
| Atomic write + 0o600 | `transfers.py:100-121` | `test_stage_file_creates_staged_copy` |
| Size cap | `transfers.py:171-176` | `test_stage_file_rejects_too_large` |
| Per-agent quota | `transfers.py:124-184` | `test_stage_file_quota_enforced` |
| TTL min-clamping | `transfers.py:190-193` | `test_sweep_removes_expired` |
| Manifest atomic | `transfers.py:215-219` | `test_stage_file_writes_manifest` |
| ACL (sender+recipient only) | `transfers.py:252-269` | `test_resolve_locator_path_enforces_acl` |
| TTL sweep | `transfers.py:289-321` | `test_sweep_removes_expired` / `_keeps_fresh` |
| Wire protocol ADR-007 §4.1 | `tools.py:352-362` | `test_tool_agent_send_file_happy_path` |

## Known limitations (documented in CHANGELOG)

- **Same-machine only** — cross-machine transfer is deferred to Option C (v0.7.1 via HTTP facade), per ADR-007 §4.
- **TTL sweep is manual** — `_transfer_sweep()` exists but is not auto-scheduled. Auto-scheduling is a follow-up.

## Out of scope (not blocking)

- No test for `TRANSFER_HASH_MISMATCH` code path (trivial, can be added in follow-up).
- No CI workflow to enforce `ruff check` + `pytest` — branch protection would carry more weight with CI.

## Attribution

- **Plan & architecture:** VLBeauClaudeOpus — `docs/plans/2026-05-01-adr-007-option-a-file-transfer.md`, `docs/adr/007-file-transfer-primitive.md`
- **Implementation (tasks 1-8 + part of 9):** GLM51 (VLBeauGLM51)
- **Review, Task 9 completion (CHANGELOG + mypy types), PR:** VLBeauClaudeOpus

Closes #33.
