### PR TITLE
fix(transfers): use facade HTTP when A2A_BUS_URL is set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.7.0"
+version = "0.7.2"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/__init__.py
+++ b/src/a2a_mcp_bridge/__init__.py
@@ -1,3 +1,3 @@
 """a2a-mcp-bridge — MCP server for agent-to-agent messaging."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.2"

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -336,12 +336,19 @@ def _facade_upload(
     Returns:
         Dict with keys ``transfer_id``, ``sha256``, ``size``,
         ``filename``, ``expires_at``, ``locator``.
+
+    Raises:
+        FileNotFoundError: Upload endpoint unreachable (404).
+        ValueError: ``TRANSFER_TOO_LARGE``, ``TRANSFER_QUOTA_EXCEEDED``,
+            or generic HTTP/network error with status code.
     """
     import json as _json
+    import urllib.error
     import urllib.request
+    import uuid
 
     url = f"{bus_url.rstrip('/')}/transfers/upload"
-    boundary = b"----A2ABoundary2026"
+    boundary = uuid.uuid4().hex.encode()
 
     filename = filepath.name
     # Build multipart/form-data body manually (stdlib only).
@@ -390,6 +397,10 @@ def _facade_upload(
             raise FileNotFoundError(f"upload endpoint not found: {url}") from exc
         if exc.code == 413:
             raise ValueError(f"TRANSFER_TOO_LARGE: {detail}") from exc
+        if exc.code == 429:
+            raise ValueError(f"TRANSFER_QUOTA_EXCEEDED: {detail}") from exc
+        if exc.code == 400:
+            raise ValueError(f"TRANSFER_BAD_REQUEST: {detail}") from exc
         raise ValueError(f"upload_transfer HTTP {exc.code}: {detail}") from exc
     except urllib.error.URLError as exc:
         raise ValueError(f"upload_transfer network error: {exc.reason}") from exc
@@ -402,19 +413,66 @@ def _facade_upload(
     return result
 
 
-def _facade_download(url: str, api_key: str, dest: Path) -> str:
+class _FacadeDownloadResult:
+    """Immutable result from :func:`_facade_download`."""
+
+    __slots__ = ("filename", "path", "sha256", "verified")
+
+    def __init__(
+        self, path: Path, sha256: str, filename: str, verified: bool
+    ) -> None:
+        self.path = path
+        self.sha256 = sha256
+        self.filename = filename
+        self.verified = verified
+
+
+def _parse_content_disposition(header: str) -> str:
+    """Extract filename from a Content-Disposition header value.
+
+    Returns the filename if found, empty string otherwise.
+    """
+    for part in header.split(";"):
+        part = part.strip()
+        if part.startswith("filename="):
+            return part.split("=", 1)[1].strip('"').strip()
+    return ""
+
+
+def _facade_download(
+    url: str,
+    api_key: str,
+    dest_dir: str,
+    verify: bool = True,
+) -> _FacadeDownloadResult:
     """Download a transfer file from the bus façade.
 
     Uses ``urllib.request`` (stdlib) to avoid a hard httpx dependency.
+    Streams the response to disk (no full-RAM buffer).
+
+    Integrity check: when ``verify=True`` and the response includes an
+    ``X-Transfer-SHA256`` header, the downloaded file's sha256 is
+    compared against it.  A mismatch raises ``ValueError``.
 
     Args:
         url: Full URL to the transfer resource.
         api_key: Bearer token for the ``Authorization`` header.
-        dest: Local path to write the file to.
+        dest_dir: Directory to write the file into (created if needed).
+        verify: If True, verify sha256 against ``X-Transfer-SHA256``
+            header when present.
 
     Returns:
-        The sha256 hex digest of the downloaded file.
+        A :class:`_FacadeDownloadResult` with ``path``, ``sha256``,
+        ``filename``, and ``verified`` fields.
+
+    Raises:
+        FileNotFoundError: Transfer not found (HTTP 404).
+        PermissionError: Access denied (HTTP 403).
+        ValueError: Hash mismatch, bad request (400), rate-limited (429),
+            or other HTTP/network error.
     """
+    import shutil
+    import urllib.error
     import urllib.request
 
     req = urllib.request.Request(
@@ -423,26 +481,75 @@ def _facade_download(url: str, api_key: str, dest: Path) -> str:
     )
 
     try:
-        with urllib.request.urlopen(req) as resp:
-            data = resp.read()
+        resp = urllib.request.urlopen(req)
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             raise FileNotFoundError(f"transfer not found: {url}") from exc
         if exc.code == 403:
             raise PermissionError(f"transfer access denied: {url}") from exc
+        if exc.code == 400:
+            detail = exc.read().decode(errors="replace")
+            raise ValueError(f"TRANSFER_BAD_REQUEST: {detail}") from exc
+        if exc.code == 429:
+            detail = exc.read().decode(errors="replace")
+            raise ValueError(f"TRANSFER_QUOTA_EXCEEDED: {detail}") from exc
         raise ValueError(f"download HTTP {exc.code}") from exc
     except urllib.error.URLError as exc:
         raise ValueError(f"download network error: {exc.reason}") from exc
 
-    # Write atomically
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_suffix(dest.suffix + ".tmp")
-    tmp.write_bytes(data)
-    tmp.rename(dest)
+    # Determine filename from Content-Disposition, fallback to URL slug.
+    cd = resp.headers.get("Content-Disposition", "")
+    filename = _parse_content_disposition(cd)
+    if not filename:
+        filename = url.rsplit("/", 1)[-1] if "/" in url else "download"
 
-    # Compute sha256
-    h = hashlib.sha256(data)
-    return h.hexdigest()
+    # Expected sha256 from header (may be absent on older façades).
+    expected_sha = resp.headers.get("X-Transfer-SHA256", "")
+
+    dest_path = Path(dest_dir) / filename
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
+
+    # Stream download — avoid buffering the entire file in RAM.
+    h = hashlib.sha256()
+    try:
+        with open(tmp_path, "wb") as fout:
+            while True:
+                chunk = resp.read(64 * 1024)
+                if not chunk:
+                    break
+                h.update(chunk)
+                fout.write(chunk)
+            fout.flush()
+            os.fsync(fout.fileno())
+        tmp_path.rename(dest_path)
+    except BaseException:
+        # Clean up temp file on any error (tempdir leak prevention).
+        tmp_path.unlink(missing_ok=True)
+        dest_path.unlink(missing_ok=True)
+        # Clean up dest_dir if we created it (best-effort, ignore errors)
+        shutil.rmtree(Path(dest_dir), ignore_errors=True)
+        raise
+    finally:
+        resp.close()
+
+    sha256_hex = h.hexdigest()
+    verified = False
+
+    if verify and expected_sha:
+        if sha256_hex != expected_sha:
+            dest_path.unlink(missing_ok=True)
+            raise ValueError(
+                f"SHA-256 mismatch for transfer: expected {expected_sha}, got {sha256_hex}"
+            )
+        verified = True
+
+    return _FacadeDownloadResult(
+        path=dest_path,
+        sha256=sha256_hex,
+        filename=filename,
+        verified=verified,
+    )
 
 
 def tool_agent_send_file(
@@ -681,13 +788,13 @@ def tool_agent_fetch_file(
         api_key = os.environ.get("A2A_FACADE_API_KEY", "")
         download_url = f"{bus_url.rstrip('/')}/transfers/{transfer_id}"
         tmp_dir = _tf.mkdtemp(prefix="a2a_fetch_")
-        dest = Path(tmp_dir) / transfer_id
 
         try:
-            sha256_hex = _facade_download(
+            dl = _facade_download(
                 url=download_url,
                 api_key=api_key,
-                dest=dest,
+                dest_dir=tmp_dir,
+                verify=verify,
             )
         except FileNotFoundError:
             return {"error": {"code": "TRANSFER_NOT_FOUND", "message": transfer_id}}
@@ -696,13 +803,13 @@ def tool_agent_fetch_file(
         except ValueError as e:
             return {"error": {"code": "TRANSFER_HASH_MISMATCH", "message": str(e)}}
 
-        file_stat = dest.stat()
+        file_stat = dl.path.stat()
         return {
             "transfer_id": transfer_id,
-            "path": str(dest),
+            "path": str(dl.path),
             "size": file_stat.st_size,
-            "sha256": sha256_hex,
-            "filename": dest.name,
+            "sha256": dl.sha256,
+            "filename": dl.filename,
             "description": "",
             "expires_at": "",
         }

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
 import time
+from pathlib import Path
 from typing import Any
 
 from .bus_store import BusStore, HttpBusStore
@@ -307,6 +310,141 @@ def _serialize_message(m: Message) -> dict[str, Any]:
     }
 
 
+def _facade_upload(
+    bus_url: str,
+    api_key: str,
+    filepath: Path,
+    sender: str,
+    recipient: str,
+    ttl_hours: int,
+) -> dict[str, Any]:
+    """Upload a file to the bus façade via POST /transfers/upload.
+
+    Uses ``urllib.request`` (stdlib) to avoid a hard dependency on httpx
+    for the *sender* side — only the HttpBusStore constructor requires
+    httpx.  This keeps ``pip install a2a-mcp-bridge`` (without ``[remote]``)
+    working for SqliteBusStore agents that only need to *upload*.
+
+    Args:
+        bus_url: Base URL of the façade (e.g. ``http://localhost:8080``).
+        api_key: Bearer token for the ``Authorization`` header.
+        filepath: Local file to upload.
+        sender: Sender agent_id.
+        recipient: Recipient agent_id.
+        ttl_hours: Time-to-live in hours.
+
+    Returns:
+        Dict with keys ``transfer_id``, ``sha256``, ``size``,
+        ``filename``, ``expires_at``, ``locator``.
+    """
+    import json as _json
+    import urllib.request
+
+    url = f"{bus_url.rstrip('/')}/transfers/upload"
+    boundary = b"----A2ABoundary2026"
+
+    filename = filepath.name
+    # Build multipart/form-data body manually (stdlib only).
+    parts: list[bytes] = []
+
+    def _add_field(name: str, value: str) -> None:
+        parts.append(b"--" + boundary + b"\r\n")
+        parts.append(
+            f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+        )
+        parts.append(value.encode() + b"\r\n")
+
+    _add_field("sender", sender)
+    _add_field("recipient", recipient)
+    _add_field("ttl_hours", str(ttl_hours))
+
+    # File part
+    parts.append(b"--" + boundary + b"\r\n")
+    parts.append(
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'.encode()
+    )
+    parts.append(b"Content-Type: application/octet-stream\r\n\r\n")
+
+    file_bytes = filepath.read_bytes()
+    parts.append(file_bytes)
+    parts.append(b"\r\n")
+    parts.append(b"--" + boundary + b"--\r\n")
+
+    body = b"".join(parts)
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary.decode()}",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result: dict[str, Any] = _json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        if exc.code == 404:
+            raise FileNotFoundError(f"upload endpoint not found: {url}") from exc
+        if exc.code == 413:
+            raise ValueError(f"TRANSFER_TOO_LARGE: {detail}") from exc
+        raise ValueError(f"upload_transfer HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ValueError(f"upload_transfer network error: {exc.reason}") from exc
+
+    # Augment with locator
+    result["locator"] = {
+        "scheme": "http",
+        "url": f"{bus_url.rstrip('/')}/transfers/{result['transfer_id']}",
+    }
+    return result
+
+
+def _facade_download(url: str, api_key: str, dest: Path) -> str:
+    """Download a transfer file from the bus façade.
+
+    Uses ``urllib.request`` (stdlib) to avoid a hard httpx dependency.
+
+    Args:
+        url: Full URL to the transfer resource.
+        api_key: Bearer token for the ``Authorization`` header.
+        dest: Local path to write the file to.
+
+    Returns:
+        The sha256 hex digest of the downloaded file.
+    """
+    import urllib.request
+
+    req = urllib.request.Request(
+        url,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise FileNotFoundError(f"transfer not found: {url}") from exc
+        if exc.code == 403:
+            raise PermissionError(f"transfer access denied: {url}") from exc
+        raise ValueError(f"download HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise ValueError(f"download network error: {exc.reason}") from exc
+
+    # Write atomically
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    tmp.write_bytes(data)
+    tmp.rename(dest)
+
+    # Compute sha256
+    h = hashlib.sha256(data)
+    return h.hexdigest()
+
+
 def tool_agent_send_file(
     store: BusStore,
     caller_id: str,
@@ -323,17 +461,84 @@ def tool_agent_send_file(
     Wire protocol: ADR-007 §4.1. The file content never enters either
     LLM's context window — only the reference message does.
 
+    Dispatch priority (v0.7.2+):
+
+    1. If ``A2A_BUS_URL`` is set in the environment → upload via the
+       façade HTTP endpoint (``_facade_upload``), regardless of whether
+       *store* is ``Store`` or ``HttpBusStore``.  This fixes the bug
+       where VPS agents using ``Store`` (direct SQLite) would stage
+       files locally — unreachable by remote (NAT'd) recipients.
+    2. If *store* is ``HttpBusStore`` (no ``A2A_BUS_URL`` but the
+       caller explicitly built an ``HttpBusStore``) → use its
+       ``upload_transfer`` method (pre-v0.7.2 Phase C path).
+    3. Otherwise → Phase A local ``stage_file`` (same-machine only).
+
     Errors returned as ``{"error": {"code": ..., "message": ...}}``:
         TRANSFER_SOURCE_NOT_FOUND, TRANSFER_TOO_LARGE,
         TRANSFER_QUOTA_EXCEEDED, <delegated from agent_send>.
     """
-    from pathlib import Path as _Path
+    import json as _json
 
-    src = _Path(file_path)
+    src = Path(file_path)
     filename = src.name
 
+    bus_url = os.environ.get("A2A_BUS_URL", "").strip()
+
+    if bus_url:
+        # --- v0.7.2: façade upload when A2A_BUS_URL is set ---
+        api_key = os.environ.get("A2A_FACADE_API_KEY", "")
+        ttl_hours = (expires_in or 86400) / 3600
+        try:
+            upload = _facade_upload(
+                bus_url=bus_url,
+                api_key=api_key,
+                filepath=src,
+                sender=caller_id,
+                recipient=target,
+                ttl_hours=int(ttl_hours),
+            )
+        except FileNotFoundError:
+            return {"error": {"code": "TRANSFER_SOURCE_NOT_FOUND", "message": str(src)}}
+        except ValueError as e:
+            code, _, msg = str(e).partition(":")
+            return {"error": {"code": code.strip(), "message": msg.strip()}}
+
+        body_obj = {
+            "kind": "file_transfer",
+            "version": 1,
+            "transfer_id": upload["transfer_id"],
+            "filename": upload["filename"],
+            "size": upload["size"],
+            "sha256": upload["sha256"],
+            "description": description,
+            "expires_at": _iso_utc(upload["expires_at"]),
+            "locator": {"scheme": "http", "url": upload["locator"]["url"]},
+        }
+
+        send_result = tool_agent_send(
+            store, caller_id, target, _json.dumps(body_obj),
+            metadata=None,
+            signal_dir=signal_dir,
+            waker=waker,
+            intent=intent,
+        )
+        if "error" in send_result:
+            return {
+                "error": send_result["error"],
+                "transfer_id": upload["transfer_id"],
+                "hint": "file uploaded but notification failed; caller may retry agent_send",
+            }
+        return {
+            "transfer_id": upload["transfer_id"],
+            "sha256": upload["sha256"],
+            "size": upload["size"],
+            "filename": upload["filename"],
+            "expires_at": body_obj["expires_at"],
+            "message_id": send_result.get("message_id"),
+        }
+
     if isinstance(store, HttpBusStore):
-        # --- Phase C: remote upload via HttpBusStore ---
+        # --- Phase C: remote upload via HttpBusStore (pre-v0.7.2 path) ---
         try:
             upload = store.upload_transfer(
                 file_path=file_path,
@@ -359,7 +564,6 @@ def tool_agent_send_file(
             "expires_at": _iso_utc(upload["expires_at"]),
             "locator": {"scheme": "http", "url": upload["locator"]["url"]},
         }
-        import json as _json
 
         send_result = tool_agent_send(
             store, caller_id, target, _json.dumps(body_obj),
@@ -412,7 +616,6 @@ def tool_agent_send_file(
         "expires_at": _iso_utc(manifest["expires_at"]),
         "locator": {"scheme": "file", "path": rec.locator_path},
     }
-    import json as _json
 
     send_result = tool_agent_send(
         store, caller_id, target, _json.dumps(body_obj),
@@ -450,12 +653,17 @@ def tool_agent_fetch_file(
     the bytes (e.g. ``read_file``) is invoked separately. Validates
     sha256 by default (cost ~50 ms per 100 MB).
 
-    Phase C (remote / HttpBusStore): the manifest lives on the façade
-    server — there is **no** local ``meta.json`` on the receiving host.
-    We short-circuit directly to ``download_transfer()`` which queries
-    the façade's SQLite-backed TransferStore.  Integrity is verified
-    via the ``X-Transfer-SHA256`` header already checked inside
-    ``HttpBusStore.download_transfer()``.
+    Dispatch priority (v0.7.2+):
+
+    1. If ``A2A_BUS_URL`` is set in the environment → download via the
+       façade HTTP endpoint (``_facade_download``), regardless of
+       whether *store* is ``Store`` or ``HttpBusStore``.
+    2. If *store* is ``HttpBusStore`` → use its ``download_transfer``
+       method (pre-v0.7.2 Phase C path).
+    3. Otherwise → Phase A local ``load_manifest`` + ``resolve_locator_path``.
+
+    Phase C (remote): the manifest lives on the façade server — there
+    is **no** local ``meta.json`` on the receiving host.
 
     Known limitation (Phase C): ``description`` and ``expires_at`` are
     returned as empty strings because the façade does not currently
@@ -463,21 +671,44 @@ def tool_agent_fetch_file(
     acceptable because the Hermes caller already has the full
     ADR-007 message body (which contains both fields) from the
     original ``agent_send_file`` notification.
-
-    Phase A (local / Store): reads ``meta.json`` from the staging dir
-    and resolves the on-disk path with ACL checks.
     """
-    # --- Phase C: remote download via HttpBusStore (no local manifest) ---
-    if isinstance(store, HttpBusStore):
-        import tempfile as _tf
-        from pathlib import Path as _Path
+    import tempfile as _tf
 
-        # Use mkdtemp (persistent) not TemporaryDirectory (context manager).
-        # TemporaryDirectory deletes the dir on __exit__, so the returned
-        # path would point to a deleted file.  mkdtemp creates the dir and
-        # leaves it alive — the caller is responsible for cleanup (the
-        # LLM tool that reads the file consumes it, then the OS reclaims
-        # the temp dir on reboot or via a janitor sweep).
+    bus_url = os.environ.get("A2A_BUS_URL", "").strip()
+
+    if bus_url:
+        # --- v0.7.2: façade download when A2A_BUS_URL is set ---
+        api_key = os.environ.get("A2A_FACADE_API_KEY", "")
+        download_url = f"{bus_url.rstrip('/')}/transfers/{transfer_id}"
+        tmp_dir = _tf.mkdtemp(prefix="a2a_fetch_")
+        dest = Path(tmp_dir) / transfer_id
+
+        try:
+            sha256_hex = _facade_download(
+                url=download_url,
+                api_key=api_key,
+                dest=dest,
+            )
+        except FileNotFoundError:
+            return {"error": {"code": "TRANSFER_NOT_FOUND", "message": transfer_id}}
+        except PermissionError as e:
+            return {"error": {"code": "TRANSFER_ACL_DENIED", "message": str(e)}}
+        except ValueError as e:
+            return {"error": {"code": "TRANSFER_HASH_MISMATCH", "message": str(e)}}
+
+        file_stat = dest.stat()
+        return {
+            "transfer_id": transfer_id,
+            "path": str(dest),
+            "size": file_stat.st_size,
+            "sha256": sha256_hex,
+            "filename": dest.name,
+            "description": "",
+            "expires_at": "",
+        }
+
+    if isinstance(store, HttpBusStore):
+        # --- Phase C: remote download via HttpBusStore (pre-v0.7.2 path) ---
         tmp_dir = _tf.mkdtemp(prefix="a2a_fetch_")
         try:
             local_path = store.download_transfer(
@@ -492,27 +723,22 @@ def tool_agent_fetch_file(
             return {"error": {"code": "TRANSFER_HASH_MISMATCH", "message": str(e)}}
 
         # Build minimal metadata from the downloaded file itself.
-        # The façade already verified SHA-256 via X-Transfer-SHA256
-        # header inside download_transfer(); re-verify only when
-        # the caller explicitly requests it (belt-and-suspenders).
-        local_file = _Path(local_path)
+        local_file = Path(local_path)
         file_stat = local_file.stat()
-        sha256_hex: str | None = None
+        dl_sha: str | None = None
 
         if verify:
-            import hashlib as _h
-
-            h = _h.sha256()
+            h = hashlib.sha256()
             with open(local_path, "rb") as f:
                 for chunk in iter(lambda: f.read(64 * 1024), b""):
                     h.update(chunk)
-            sha256_hex = h.hexdigest()
+            dl_sha = h.hexdigest()
 
         return {
             "transfer_id": transfer_id,
             "path": str(local_path),
             "size": file_stat.st_size,
-            "sha256": sha256_hex or "",
+            "sha256": dl_sha or "",
             "filename": local_file.name,
             "description": "",
             "expires_at": "",
@@ -534,9 +760,7 @@ def tool_agent_fetch_file(
         return {"error": {"code": "TRANSFER_ACL_DENIED", "message": str(e)}}
 
     if verify:
-        import hashlib as _h
-
-        h = _h.sha256()
+        h = hashlib.sha256()
         with open(path, "rb") as f:
             for chunk in iter(lambda: f.read(64 * 1024), b""):
                 h.update(chunk)

--- a/tests/test_transfer_dispatch.py
+++ b/tests/test_transfer_dispatch.py
@@ -1,15 +1,20 @@
 """Tests for v0.7.2 transfer dispatch: A2A_BUS_URL overrides store type.
 
 Bug: agents using Store (direct SQLite) with A2A_BUS_URL set would stage
-files locally (Phase A) — unreachable by remote (NAT'd) recipients.
+files locally (Phase A) -- unreachable by remote (NAT'd) recipients.
 
 Fix: when A2A_BUS_URL is in the environment, agent_send_file and
-agent_fetch_file always use the façade HTTP endpoint, regardless of
+agent_fetch_file always use the facade HTTP endpoint, regardless of
 whether the store is Store or HttpBusStore.
+
+C5 coverage: tests 6-13 exercise _facade_upload and _facade_download
+directly by mocking urllib.request.urlopen (not the wrapper functions),
+ensuring the actual HTTP helper code is covered.
 """
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import time
 from pathlib import Path
@@ -20,6 +25,10 @@ import pytest
 from a2a_mcp_bridge.bus_store import HttpBusStore
 from a2a_mcp_bridge.store import Store
 from a2a_mcp_bridge.tools import (
+    _facade_download,
+    _facade_upload,
+    _FacadeDownloadResult,
+    _parse_content_disposition,
     tool_agent_fetch_file,
     tool_agent_send_file,
 )
@@ -65,8 +74,29 @@ def _make_mock_http_store() -> MagicMock:
     return mock
 
 
+def _fake_urlopen_response(
+    data: bytes = b"",
+    headers: dict[str, str] | None = None,
+    status: int = 200,
+) -> MagicMock:
+    """Build a mock that looks like a urllib.response object."""
+    resp = MagicMock()
+    resp.read = MagicMock(return_value=data)
+    resp.headers = MagicMock()
+    if headers:
+        resp.headers.get = MagicMock(
+            side_effect=lambda key, default="", _h=headers: _h.get(key, default)
+        )
+    else:
+        resp.headers.get = MagicMock(return_value="")
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.close = MagicMock()
+    return resp
+
+
 # ---------------------------------------------------------------------------
-# 1. test_send_file_store_with_bus_url → must call _facade_upload
+# 1. test_send_file_store_with_bus_url -> must call _facade_upload
 # ---------------------------------------------------------------------------
 
 
@@ -76,10 +106,10 @@ def test_send_file_store_with_bus_url(
     transfer_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Store + A2A_BUS_URL set → _facade_upload is used, NOT stage_file.
+    """Store + A2A_BUS_URL set -> _facade_upload is used, NOT stage_file.
 
     This is the core bug fix: VPS agents using Store (direct SQLite)
-    must upload via the façade when A2A_BUS_URL is defined.
+    must upload via the facade when A2A_BUS_URL is defined.
     """
     monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
     monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-123")
@@ -134,7 +164,7 @@ def test_send_file_store_with_bus_url(
 
 
 # ---------------------------------------------------------------------------
-# 2. test_send_file_store_without_bus_url → must stage locally (Phase A)
+# 2. test_send_file_store_without_bus_url -> must stage locally (Phase A)
 # ---------------------------------------------------------------------------
 
 
@@ -144,9 +174,9 @@ def test_send_file_store_without_bus_url(
     transfer_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Store + A2A_BUS_URL NOT set → local stage_file (Phase A).
+    """Store + A2A_BUS_URL NOT set -> local stage_file (Phase A).
 
-    This is the unchanged behaviour: same-VPS agents without a façade
+    This is the unchanged behaviour: same-VPS agents without a facade
     continue to use local staging.
     """
     # Ensure A2A_BUS_URL is NOT set
@@ -175,7 +205,7 @@ def test_send_file_store_without_bus_url(
 
 
 # ---------------------------------------------------------------------------
-# 3. test_send_file_http_store → must call _facade_upload when A2A_BUS_URL set
+# 3. test_send_file_http_store -> must call _facade_upload when A2A_BUS_URL set
 # ---------------------------------------------------------------------------
 
 
@@ -183,10 +213,10 @@ def test_send_file_http_store_with_bus_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HttpBusStore + A2A_BUS_URL set → _facade_upload is used (priority 1).
+    """HttpBusStore + A2A_BUS_URL set -> _facade_upload is used (priority 1).
 
     Even when the store is HttpBusStore, A2A_BUS_URL takes precedence
-    over isinstance(store, HttpBusStore) — ensuring a single code path.
+    over isinstance(store, HttpBusStore) -- ensuring a single code path.
     """
     monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
     monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-456")
@@ -225,7 +255,7 @@ def test_send_file_http_store_with_bus_url(
 
 
 # ---------------------------------------------------------------------------
-# 4. test_fetch_file_http_locator_with_bus_url → must call _facade_download
+# 4. test_fetch_file_http_locator_with_bus_url -> must call _facade_download
 # ---------------------------------------------------------------------------
 
 
@@ -234,10 +264,10 @@ def test_fetch_file_http_locator_with_bus_url(
     local_store: Store,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Store + A2A_BUS_URL set → _facade_download is used for fetch.
+    """Store + A2A_BUS_URL set -> _facade_download is used for fetch.
 
     The receiving agent (e.g. macqwen36 behind NAT) uses Store for
-    messages but must download the file from the façade via HTTP.
+    messages but must download the file from the facade via HTTP.
     """
     monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
     monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-789")
@@ -246,14 +276,21 @@ def test_fetch_file_http_locator_with_bus_url(
     content = b"remote file content"
     expected_sha = hashlib.sha256(content).hexdigest()
 
-    with patch("a2a_mcp_bridge.tools._facade_download") as mock_download:
-        # _facade_download writes the file and returns sha256
-        def _fake_download(url: str, api_key: str, dest: Path) -> str:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(content)
-            return expected_sha
+    # Create the file on disk so dl.path.stat() works in fetch_file
+    fake_dir = tmp_path / "a2a_fetch_fake"
+    fake_dir.mkdir()
+    fake_path = fake_dir / "real_name.txt"
+    fake_path.write_bytes(content)
 
-        mock_download.side_effect = _fake_download
+    fake_result = _FacadeDownloadResult(
+        path=fake_path,
+        sha256=expected_sha,
+        filename="real_name.txt",
+        verified=True,
+    )
+
+    with patch("a2a_mcp_bridge.tools._facade_download") as mock_download:
+        mock_download.return_value = fake_result
 
         result = tool_agent_fetch_file(
             local_store,
@@ -262,23 +299,22 @@ def test_fetch_file_http_locator_with_bus_url(
             verify=True,
         )
 
-        # _facade_download was called
+        # _facade_download was called with correct args
         mock_download.assert_called_once()
         call_kwargs = mock_download.call_args.kwargs
         assert call_kwargs["url"] == "http://bus.test:8080/transfers/remote-fetch-tid"
         assert call_kwargs["api_key"] == "test-key-789"
+        assert call_kwargs["verify"] is True
 
     assert "error" not in result
     assert result["transfer_id"] == tid
     assert result["sha256"] == expected_sha
-    assert result["size"] == len(content)
-    # File exists on disk
-    assert Path(result["path"]).exists()
-    assert Path(result["path"]).read_bytes() == content
+    # C3 fix: filename comes from _FacadeDownloadResult, NOT transfer_id
+    assert result["filename"] == "real_name.txt"
 
 
 # ---------------------------------------------------------------------------
-# 5. test_fetch_file_file_locator_without_bus_url → must read locally
+# 5. test_fetch_file_file_locator_without_bus_url -> must read locally
 # ---------------------------------------------------------------------------
 
 
@@ -288,7 +324,7 @@ def test_fetch_file_file_locator_without_bus_url(
     transfer_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Store + A2A_BUS_URL NOT set → Phase A local fetch (manifest on disk).
+    """Store + A2A_BUS_URL NOT set -> Phase A local fetch (manifest on disk).
 
     Non-regression: same-machine transfers continue to use the local
     staging directory.
@@ -320,3 +356,576 @@ def test_fetch_file_file_locator_without_bus_url(
     assert "error" not in result
     assert result["filename"] == "local_data.txt"
     assert Path(result["path"]).read_text() == "local data here"
+
+
+# ===========================================================================
+# C5: Direct unit tests for _facade_upload and _facade_download
+# These mock urllib.request.urlopen (not the wrapper) to exercise the
+# actual HTTP helper code and improve coverage.
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# 6. test_facade_upload_success -> POST multipart, return augmented dict
+# ---------------------------------------------------------------------------
+
+
+def test_facade_upload_success(tmp_path: Path) -> None:
+    """_facade_upload sends a POST with multipart body and returns the
+    facade response augmented with a locator dict."""
+    src = tmp_path / "upload_test.txt"
+    src.write_text("hello world")
+
+    upload_resp = json.dumps({
+        "transfer_id": "tid-upload-001",
+        "filename": "upload_test.txt",
+        "size": 11,
+        "sha256": "d" * 64,
+        "expires_at": time.time() + 86400,
+    }).encode()
+
+    mock_resp = _fake_urlopen_response(data=upload_resp)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        result = _facade_upload(
+            bus_url="http://bus.test:8080",
+            api_key="key-123",
+            filepath=src,
+            sender="alice",
+            recipient="bob",
+            ttl_hours=24,
+        )
+
+    assert result["transfer_id"] == "tid-upload-001"
+    assert result["filename"] == "upload_test.txt"
+    assert result["size"] == 11
+    # Locator was augmented
+    assert result["locator"]["scheme"] == "http"
+    assert result["locator"]["url"] == "http://bus.test:8080/transfers/tid-upload-001"
+
+
+# ---------------------------------------------------------------------------
+# 7. test_facade_upload_http_errors -> 413, 429, 400, 404
+# ---------------------------------------------------------------------------
+
+
+def test_facade_upload_http_errors(tmp_path: Path) -> None:
+    """_facade_upload maps HTTP errors to the correct exception types."""
+    import urllib.error
+
+    src = tmp_path / "err.txt"
+    src.write_text("data")
+
+    # 413 -> ValueError TRANSFER_TOO_LARGE
+    err_413 = urllib.error.HTTPError(
+        "http://x", 413, "Too Large", {}, io.BytesIO(b"too big")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_413), \
+         pytest.raises(ValueError, match="TRANSFER_TOO_LARGE"):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+    # 429 -> ValueError TRANSFER_QUOTA_EXCEEDED
+    err_429 = urllib.error.HTTPError(
+        "http://x", 429, "Rate Limit", {}, io.BytesIO(b"slow down")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_429), \
+         pytest.raises(ValueError, match="TRANSFER_QUOTA_EXCEEDED"):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+    # 400 -> ValueError TRANSFER_BAD_REQUEST
+    err_400 = urllib.error.HTTPError(
+        "http://x", 400, "Bad Request", {}, io.BytesIO(b"invalid")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_400), \
+         pytest.raises(ValueError, match="TRANSFER_BAD_REQUEST"):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+    # 404 -> FileNotFoundError
+    err_404 = urllib.error.HTTPError(
+        "http://x", 404, "Not Found", {}, io.BytesIO(b"nope")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_404), \
+         pytest.raises(FileNotFoundError):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+
+# ---------------------------------------------------------------------------
+# 8. test_facade_download_success -> streams file, extracts filename, verifies sha
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_success(tmp_path: Path) -> None:
+    """_facade_download streams to disk, parses Content-Disposition, and
+    verifies sha256 against X-Transfer-SHA256 header."""
+    content = b"downloaded content"
+    expected_sha = hashlib.sha256(content).hexdigest()
+
+    # Simulate a response that streams in chunks
+    chunks = [content[:10], content[10:]]
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="report.csv"',
+            "X-Transfer-SHA256": expected_sha,
+        }.get(key, default)
+    )
+    read_iter = iter([*chunks, b""])
+
+    def _read(size: int = -1) -> bytes:
+        try:
+            return next(read_iter)
+        except StopIteration:
+            return b""
+
+    resp.read = _read
+    resp.close = MagicMock()
+
+    dest_dir = str(tmp_path / "download")
+
+    with patch("urllib.request.urlopen", return_value=resp):
+        result = _facade_download(
+            url="http://bus.test:8080/transfers/tid-123",
+            api_key="key-456",
+            dest_dir=dest_dir,
+            verify=True,
+        )
+
+    assert isinstance(result, _FacadeDownloadResult)
+    assert result.filename == "report.csv"  # C3: real filename from Content-Disposition
+    assert result.sha256 == expected_sha
+    assert result.verified is True
+    # File on disk matches
+    assert result.path.read_bytes() == content
+    assert result.path.name == "report.csv"
+
+
+# ---------------------------------------------------------------------------
+# 9. test_facade_download_sha_mismatch -> corrupt file rejected
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_sha_mismatch(tmp_path: Path) -> None:
+    """C4: _facade_download raises ValueError when sha256 mismatches
+    X-Transfer-SHA256 header. Corrupt data in transit is rejected."""
+    content = b"corrupted content"
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="bad.bin"',
+            "X-Transfer-SHA256": "0" * 64,  # wrong hash
+        }.get(key, default)
+    )
+    resp.read = MagicMock(side_effect=[content, b""])
+    resp.close = MagicMock()
+
+    dest_dir = str(tmp_path / "download_bad")
+
+    with patch("urllib.request.urlopen", return_value=resp), \
+         pytest.raises(ValueError, match="SHA-256 mismatch"):
+        _facade_download(
+            url="http://bus.test:8080/transfers/tid-bad",
+            api_key="k",
+            dest_dir=dest_dir,
+            verify=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. test_facade_download_verify_false -> no sha mismatch raised
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_verify_false(tmp_path: Path) -> None:
+    """M1: verify=False skips the sha256 comparison even when header
+    is present and wrong."""
+    content = b"some data"
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="skip.bin"',
+            "X-Transfer-SHA256": "0" * 64,  # wrong hash
+        }.get(key, default)
+    )
+    resp.read = MagicMock(side_effect=[content, b""])
+    resp.close = MagicMock()
+
+    dest_dir = str(tmp_path / "download_skip")
+
+    with patch("urllib.request.urlopen", return_value=resp):
+        result = _facade_download(
+            url="http://bus.test:8080/transfers/tid-skip",
+            api_key="k",
+            dest_dir=dest_dir,
+            verify=False,
+        )
+
+    # No ValueError raised despite wrong hash
+    assert result.filename == "skip.bin"
+    assert result.verified is False
+    assert result.path.read_bytes() == content
+
+
+# ---------------------------------------------------------------------------
+# 11. test_facade_download_http_errors -> 404, 403, 429
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_http_errors() -> None:
+    """M3: _facade_download maps HTTP errors to specific exception types."""
+    import urllib.error
+
+    # 404 -> FileNotFoundError
+    err_404 = urllib.error.HTTPError(
+        "http://x", 404, "Not Found", {}, io.BytesIO(b"nope")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_404), \
+         pytest.raises(FileNotFoundError):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+    # 403 -> PermissionError
+    err_403 = urllib.error.HTTPError(
+        "http://x", 403, "Forbidden", {}, io.BytesIO(b"denied")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_403), \
+         pytest.raises(PermissionError):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+    # 429 -> ValueError TRANSFER_QUOTA_EXCEEDED
+    err_429 = urllib.error.HTTPError(
+        "http://x", 429, "Rate Limit", {}, io.BytesIO(b"slow")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_429), \
+         pytest.raises(ValueError, match="TRANSFER_QUOTA_EXCEEDED"):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+
+# ---------------------------------------------------------------------------
+# 12. test_parse_content_disposition -> various header formats
+# ---------------------------------------------------------------------------
+
+
+def test_parse_content_disposition() -> None:
+    """_parse_content_disposition extracts filename from various formats."""
+    assert _parse_content_disposition('attachment; filename="report.csv"') == "report.csv"
+    assert _parse_content_disposition("attachment; filename=data.bin") == "data.bin"
+    assert _parse_content_disposition("attachment") == ""
+    assert _parse_content_disposition("") == ""
+    assert _parse_content_disposition('inline; filename="my file.txt"') == "my file.txt"
+
+
+# ---------------------------------------------------------------------------
+# 13. test_facade_download_no_content_disposition -> fallback to URL slug
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_no_content_disposition(tmp_path: Path) -> None:
+    """When no Content-Disposition header, filename falls back to URL slug."""
+    content = b"no cd header"
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(return_value="")  # no headers
+    resp.read = MagicMock(side_effect=[content, b""])
+    resp.close = MagicMock()
+
+    dest_dir = str(tmp_path / "download_nocd")
+
+    with patch("urllib.request.urlopen", return_value=resp):
+        result = _facade_download(
+            url="http://bus.test:8080/transfers/tid-nocd",
+            api_key="k",
+            dest_dir=dest_dir,
+            verify=False,
+        )
+
+    # Filename fallback from URL slug
+    assert result.filename == "tid-nocd"
+    assert result.path.name == "tid-nocd"
+
+
+# ---------------------------------------------------------------------------
+# C5 coverage gap fillers
+# ---------------------------------------------------------------------------
+
+
+def test_facade_upload_generic_http_error(tmp_path: Path) -> None:
+    """Cover line 404: _facade_upload raises ValueError for unhandled HTTP codes."""
+    import urllib.error
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"x")
+
+    err_500 = urllib.error.HTTPError(
+        "http://x", 500, "Internal Server Error", {}, io.BytesIO(b"boom")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_500), \
+         pytest.raises(ValueError, match="upload_transfer HTTP 500"):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+
+def test_facade_upload_urlerror(tmp_path: Path) -> None:
+    """Cover line 405-406: _facade_upload raises ValueError on URLError."""
+    import urllib.error
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"x")
+
+    err = urllib.error.URLError("connection refused")
+    with patch("urllib.request.urlopen", side_effect=err), \
+         pytest.raises(ValueError, match="upload_transfer network error"):
+        _facade_upload("http://bus", "k", src, "a", "b", 24)
+
+
+def test_facade_download_http_400() -> None:
+    """Cover lines 491-492: _facade_download maps 400 to ValueError."""
+    import urllib.error
+
+    err_400 = urllib.error.HTTPError(
+        "http://x", 400, "Bad Request", {}, io.BytesIO(b"invalid")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_400), \
+         pytest.raises(ValueError, match="TRANSFER_BAD_REQUEST"):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+
+def test_facade_download_generic_http_error() -> None:
+    """Cover line 496: _facade_download raises ValueError for unhandled HTTP codes."""
+    import urllib.error
+
+    err_500 = urllib.error.HTTPError(
+        "http://x", 500, "Internal Server Error", {}, io.BytesIO(b"oops")
+    )
+    with patch("urllib.request.urlopen", side_effect=err_500), \
+         pytest.raises(ValueError, match="download HTTP 500"):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+
+def test_facade_download_urlerror() -> None:
+    """Cover lines 497-498: _facade_download raises ValueError on URLError."""
+    import urllib.error
+
+    err = urllib.error.URLError("connection refused")
+    with patch("urllib.request.urlopen", side_effect=err), \
+         pytest.raises(ValueError, match="download network error"):
+        _facade_download("http://bus/xfrs/t1", "k", "/tmp/d")
+
+
+def test_facade_download_cleanup_on_write_error(tmp_path: Path) -> None:
+    """Cover lines 526-532: BaseException during download cleans up temp files."""
+    content = b"will fail"
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="fail.bin"',
+        }.get(key, default)
+    )
+    resp.read = MagicMock(side_effect=[content, OSError("disk full")])
+    resp.close = MagicMock()
+
+    dest_dir = str(tmp_path / "cleanup_test")
+    with patch("urllib.request.urlopen", return_value=resp), \
+         pytest.raises(OSError, match="disk full"):
+        _facade_download(
+            url="http://bus.test:8080/transfers/tid-fail",
+            api_key="k",
+            dest_dir=dest_dir,
+            verify=False,
+        )
+
+
+def test_send_file_facade_upload_filenotfound(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 607-608: facade upload FileNotFoundError in send_file."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    src = tmp_path / "gone.txt"
+    src.write_text("data")
+
+    with patch("a2a_mcp_bridge.tools._facade_upload", side_effect=FileNotFoundError("nope")):
+        result = tool_agent_send_file(local_store, "alice", "bob", str(src))
+
+    assert result["error"]["code"] == "TRANSFER_SOURCE_NOT_FOUND"
+
+
+def test_send_file_facade_upload_valueerror(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 609-611: facade upload ValueError in send_file."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    src = tmp_path / "big.txt"
+    src.write_text("data")
+
+    with patch("a2a_mcp_bridge.tools._facade_upload", side_effect=ValueError("TRANSFER_TOO_LARGE: file too big")):
+        result = tool_agent_send_file(local_store, "alice", "bob", str(src))
+
+    assert result["error"]["code"] == "TRANSFER_TOO_LARGE"
+
+
+def test_send_file_facade_send_error(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover line 633: send_result has error after successful facade upload."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    src = tmp_path / "msg.txt"
+    src.write_text("data")
+
+    upload_result = {
+        "transfer_id": "tid-se", "filename": "msg.txt", "size": 4,
+        "sha256": "a" * 64, "expires_at": time.time() + 86400,
+        "locator": {"scheme": "http", "url": "http://bus/transfers/tid-se"},
+    }
+
+    with patch("a2a_mcp_bridge.tools._facade_upload", return_value=upload_result), \
+         patch("a2a_mcp_bridge.tools.tool_agent_send", return_value={"error": {"code": "TARGET_NOT_FOUND", "message": "nope"}}):
+        result = tool_agent_send_file(local_store, "alice", "bob", str(src))
+
+    assert result["error"]["code"] == "TARGET_NOT_FOUND"
+    assert result["transfer_id"] == "tid-se"
+    assert "hint" in result
+
+
+def test_send_file_http_store_upload_filenotfound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 657-658: HttpBusStore upload FileNotFoundError."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.upload_transfer = MagicMock(side_effect=FileNotFoundError("nope"))
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"x")
+
+    result = tool_agent_send_file(mock_store, "alice", "bob", str(src))
+    assert result["error"]["code"] == "TRANSFER_SOURCE_NOT_FOUND"
+
+
+def test_send_file_http_store_upload_valueerror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 659-661: HttpBusStore upload ValueError."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.upload_transfer = MagicMock(side_effect=ValueError("TRANSFER_TOO_LARGE: big"))
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"x")
+
+    result = tool_agent_send_file(mock_store, "alice", "bob", str(src))
+    assert result["error"]["code"] == "TRANSFER_TOO_LARGE"
+
+
+def test_send_file_http_store_send_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover line 683: HttpBusStore send_result error after upload."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.upload_transfer = MagicMock(return_value={
+        "transfer_id": "tid-hb", "filename": "f.bin", "size": 1,
+        "sha256": "c" * 64, "expires_at": time.time() + 86400,
+        "locator": {"scheme": "http", "url": "http://bus/transfers/tid-hb"},
+    })
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"x")
+
+    with patch("a2a_mcp_bridge.tools.tool_agent_send", return_value={"error": {"code": "TARGET_NOT_FOUND", "message": "nope"}}):
+        result = tool_agent_send_file(mock_store, "alice", "bob", str(src))
+
+    assert result["error"]["code"] == "TARGET_NOT_FOUND"
+    assert result["transfer_id"] == "tid-hb"
+
+
+def test_fetch_file_facade_download_notfound(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover line 799-800: facade download FileNotFoundError in fetch."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    with patch("a2a_mcp_bridge.tools._facade_download", side_effect=FileNotFoundError("nope")):
+        result = tool_agent_fetch_file(local_store, "alice", "tid-missing")
+
+    assert result["error"]["code"] == "TRANSFER_NOT_FOUND"
+
+
+def test_fetch_file_facade_download_permission(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 801-802: facade download PermissionError in fetch."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    with patch("a2a_mcp_bridge.tools._facade_download", side_effect=PermissionError("denied")):
+        result = tool_agent_fetch_file(local_store, "alice", "tid-denied")
+
+    assert result["error"]["code"] == "TRANSFER_ACL_DENIED"
+
+
+def test_fetch_file_facade_download_hash_mismatch(
+    tmp_path: Path, local_store: Store, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 803-804: facade download ValueError (hash mismatch) in fetch."""
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "k")
+
+    with patch("a2a_mcp_bridge.tools._facade_download", side_effect=ValueError("SHA-256 mismatch")):
+        result = tool_agent_fetch_file(local_store, "alice", "tid-bad")
+
+    assert result["error"]["code"] == "TRANSFER_HASH_MISMATCH"
+
+
+def test_fetch_file_http_store_notfound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 824-825: HttpBusStore download FileNotFoundError."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.download_transfer = MagicMock(side_effect=FileNotFoundError("nope"))
+
+    result = tool_agent_fetch_file(mock_store, "alice", "tid-gone")
+    assert result["error"]["code"] == "TRANSFER_NOT_FOUND"
+
+
+def test_fetch_file_http_store_permission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 826-827: HttpBusStore download PermissionError."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.download_transfer = MagicMock(side_effect=PermissionError("denied"))
+
+    result = tool_agent_fetch_file(mock_store, "alice", "tid-denied")
+    assert result["error"]["code"] == "TRANSFER_ACL_DENIED"
+
+
+def test_fetch_file_http_store_hash_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover lines 828-830: HttpBusStore download ValueError (hash mismatch)."""
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    mock_store = _make_mock_http_store()
+    mock_store.download_transfer = MagicMock(side_effect=ValueError("SHA-256 mismatch"))
+
+    result = tool_agent_fetch_file(mock_store, "alice", "tid-bad")
+    assert result["error"]["code"] == "TRANSFER_HASH_MISMATCH"

--- a/tests/test_transfer_dispatch.py
+++ b/tests/test_transfer_dispatch.py
@@ -1,0 +1,322 @@
+"""Tests for v0.7.2 transfer dispatch: A2A_BUS_URL overrides store type.
+
+Bug: agents using Store (direct SQLite) with A2A_BUS_URL set would stage
+files locally (Phase A) — unreachable by remote (NAT'd) recipients.
+
+Fix: when A2A_BUS_URL is in the environment, agent_send_file and
+agent_fetch_file always use the façade HTTP endpoint, regardless of
+whether the store is Store or HttpBusStore.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from a2a_mcp_bridge.bus_store import HttpBusStore
+from a2a_mcp_bridge.store import Store
+from a2a_mcp_bridge.tools import (
+    tool_agent_fetch_file,
+    tool_agent_send_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def local_store(tmp_path: Path) -> Store:
+    """Create a real SQLite-backed Store with alice and bob registered."""
+    s = Store(str(tmp_path / "bus.db"))
+    s.init_schema()
+    s.upsert_agent("alice")
+    s.upsert_agent("bob")
+    return s
+
+
+@pytest.fixture()
+def transfer_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Set A2A_TRANSFER_DIR to a tmp directory and return it."""
+    td = tmp_path / "xfer"
+    monkeypatch.setenv("A2A_TRANSFER_DIR", str(td))
+    return td
+
+
+def _make_mock_http_store() -> MagicMock:
+    """Create a MagicMock(spec=HttpBusStore) so isinstance checks pass."""
+    mock = MagicMock(spec=HttpBusStore)
+    mock.upsert_agent = MagicMock()
+    from datetime import UTC, datetime
+
+    from a2a_mcp_bridge.models import SendResult
+
+    mock.send_message = MagicMock(
+        return_value=SendResult(
+            message_id="msg-001",
+            sent_at=datetime.now(UTC),
+            recipient="bob",
+        )
+    )
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# 1. test_send_file_store_with_bus_url → must call _facade_upload
+# ---------------------------------------------------------------------------
+
+
+def test_send_file_store_with_bus_url(
+    tmp_path: Path,
+    local_store: Store,
+    transfer_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Store + A2A_BUS_URL set → _facade_upload is used, NOT stage_file.
+
+    This is the core bug fix: VPS agents using Store (direct SQLite)
+    must upload via the façade when A2A_BUS_URL is defined.
+    """
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-123")
+
+    src = tmp_path / "report.md"
+    src.write_text("# Report\n")
+
+    upload_response = {
+        "transfer_id": "facade-tid-001",
+        "filename": "report.md",
+        "size": 10,
+        "sha256": "b" * 64,
+        "expires_at": time.time() + 86400,
+    }
+
+    with patch("a2a_mcp_bridge.tools._facade_upload") as mock_upload:
+        mock_upload.return_value = {
+            **upload_response,
+            "locator": {
+                "scheme": "http",
+                "url": "http://bus.test:8080/transfers/facade-tid-001",
+            },
+        }
+
+        result = tool_agent_send_file(
+            local_store,
+            caller_id="alice",
+            target="bob",
+            file_path=str(src),
+            description="via facade",
+        )
+
+        # _facade_upload was called (not stage_file)
+        mock_upload.assert_called_once()
+        call_kwargs = mock_upload.call_args.kwargs
+        assert call_kwargs["bus_url"] == "http://bus.test:8080"
+        assert call_kwargs["api_key"] == "test-key-123"
+        assert call_kwargs["sender"] == "alice"
+        assert call_kwargs["recipient"] == "bob"
+
+    # Result has facade transfer_id, NOT a local one
+    assert "error" not in result
+    assert result["transfer_id"] == "facade-tid-001"
+    assert result["sha256"] == "b" * 64
+
+    # The message body in the inbox must have locator.scheme == "http"
+    msgs = local_store.read_inbox("bob")
+    assert len(msgs) == 1
+    body = json.loads(msgs[0].body)
+    assert body["locator"]["scheme"] == "http"
+    assert body["locator"]["url"] == "http://bus.test:8080/transfers/facade-tid-001"
+
+
+# ---------------------------------------------------------------------------
+# 2. test_send_file_store_without_bus_url → must stage locally (Phase A)
+# ---------------------------------------------------------------------------
+
+
+def test_send_file_store_without_bus_url(
+    tmp_path: Path,
+    local_store: Store,
+    transfer_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Store + A2A_BUS_URL NOT set → local stage_file (Phase A).
+
+    This is the unchanged behaviour: same-VPS agents without a façade
+    continue to use local staging.
+    """
+    # Ensure A2A_BUS_URL is NOT set
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    src = tmp_path / "local.txt"
+    src.write_text("local content")
+
+    result = tool_agent_send_file(
+        local_store,
+        caller_id="alice",
+        target="bob",
+        file_path=str(src),
+    )
+
+    assert "error" not in result
+    assert result["transfer_id"]
+    assert result["size"] > 0
+
+    # Locator must be file scheme
+    msgs = local_store.read_inbox("bob")
+    assert len(msgs) == 1
+    body = json.loads(msgs[0].body)
+    assert body["locator"]["scheme"] == "file"
+    assert "path" in body["locator"]
+
+
+# ---------------------------------------------------------------------------
+# 3. test_send_file_http_store → must call _facade_upload when A2A_BUS_URL set
+# ---------------------------------------------------------------------------
+
+
+def test_send_file_http_store_with_bus_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HttpBusStore + A2A_BUS_URL set → _facade_upload is used (priority 1).
+
+    Even when the store is HttpBusStore, A2A_BUS_URL takes precedence
+    over isinstance(store, HttpBusStore) — ensuring a single code path.
+    """
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-456")
+
+    mock_store = _make_mock_http_store()
+
+    src = tmp_path / "data.bin"
+    src.write_bytes(b"\x00\x01\x02")
+
+    with patch("a2a_mcp_bridge.tools._facade_upload") as mock_upload:
+        mock_upload.return_value = {
+            "transfer_id": "facade-tid-002",
+            "filename": "data.bin",
+            "size": 3,
+            "sha256": "c" * 64,
+            "expires_at": time.time() + 86400,
+            "locator": {
+                "scheme": "http",
+                "url": "http://bus.test:8080/transfers/facade-tid-002",
+            },
+        }
+
+        result = tool_agent_send_file(
+            mock_store,
+            caller_id="alice",
+            target="bob",
+            file_path=str(src),
+        )
+
+        # _facade_upload was called, NOT store.upload_transfer
+        mock_upload.assert_called_once()
+        mock_store.upload_transfer.assert_not_called()
+
+    assert "error" not in result
+    assert result["transfer_id"] == "facade-tid-002"
+
+
+# ---------------------------------------------------------------------------
+# 4. test_fetch_file_http_locator_with_bus_url → must call _facade_download
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_file_http_locator_with_bus_url(
+    tmp_path: Path,
+    local_store: Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Store + A2A_BUS_URL set → _facade_download is used for fetch.
+
+    The receiving agent (e.g. macqwen36 behind NAT) uses Store for
+    messages but must download the file from the façade via HTTP.
+    """
+    monkeypatch.setenv("A2A_BUS_URL", "http://bus.test:8080")
+    monkeypatch.setenv("A2A_FACADE_API_KEY", "test-key-789")
+
+    tid = "remote-fetch-tid"
+    content = b"remote file content"
+    expected_sha = hashlib.sha256(content).hexdigest()
+
+    with patch("a2a_mcp_bridge.tools._facade_download") as mock_download:
+        # _facade_download writes the file and returns sha256
+        def _fake_download(url: str, api_key: str, dest: Path) -> str:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(content)
+            return expected_sha
+
+        mock_download.side_effect = _fake_download
+
+        result = tool_agent_fetch_file(
+            local_store,
+            caller_id="bob",
+            transfer_id=tid,
+            verify=True,
+        )
+
+        # _facade_download was called
+        mock_download.assert_called_once()
+        call_kwargs = mock_download.call_args.kwargs
+        assert call_kwargs["url"] == "http://bus.test:8080/transfers/remote-fetch-tid"
+        assert call_kwargs["api_key"] == "test-key-789"
+
+    assert "error" not in result
+    assert result["transfer_id"] == tid
+    assert result["sha256"] == expected_sha
+    assert result["size"] == len(content)
+    # File exists on disk
+    assert Path(result["path"]).exists()
+    assert Path(result["path"]).read_bytes() == content
+
+
+# ---------------------------------------------------------------------------
+# 5. test_fetch_file_file_locator_without_bus_url → must read locally
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_file_file_locator_without_bus_url(
+    tmp_path: Path,
+    local_store: Store,
+    transfer_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Store + A2A_BUS_URL NOT set → Phase A local fetch (manifest on disk).
+
+    Non-regression: same-machine transfers continue to use the local
+    staging directory.
+    """
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+
+    src = tmp_path / "local_data.txt"
+    src.write_text("local data here")
+
+    # Send first to stage the file
+    sent = tool_agent_send_file(
+        local_store,
+        caller_id="alice",
+        target="bob",
+        file_path=str(src),
+    )
+    assert "error" not in sent
+
+    # Fetch must use local manifest (Phase A)
+    with patch("a2a_mcp_bridge.tools._facade_download") as mock_download:
+        result = tool_agent_fetch_file(
+            local_store,
+            caller_id="bob",
+            transfer_id=sent["transfer_id"],
+        )
+        # _facade_download must NOT be called
+        mock_download.assert_not_called()
+
+    assert "error" not in result
+    assert result["filename"] == "local_data.txt"
+    assert Path(result["path"]).read_text() == "local data here"


### PR DESCRIPTION
## Bug

VPS agents using `Store` (direct SQLite) with `A2A_BUS_URL` set in the environment would stage files locally via Phase A (`stage_file`). The staged files live on the VPS filesystem and are unreachable by remote agents behind NAT (e.g. macqwen36).

Root cause: `tool_agent_send_file` and `tool_agent_fetch_file` dispatched based on `isinstance(store, HttpBusStore)`, ignoring the `A2A_BUS_URL` env var that signals a façade is available.

## Fix (v0.7.2)

**Dispatch priority change:**

1. `A2A_BUS_URL` is set → use `_facade_upload` / `_facade_download` (stdlib `urllib.request`), regardless of store type
2. `isinstance(store, HttpBusStore)` → existing Phase C path via `store.upload_transfer` / `store.download_transfer`
3. Otherwise → Phase A local staging (unchanged)

**New helpers:**

- `_facade_upload(bus_url, api_key, filepath, sender, recipient, ttl_hours)` — POST multipart/form-data to `{bus_url}/transfers/upload`
- `_facade_download(url, api_key, dest)` — GET with Bearer token, write atomically, return sha256

Both use `urllib.request` (stdlib) to avoid a hard httpx dependency for `Store`-only agents.

**Env vars used (already existing convention):**
- `A2A_BUS_URL` — façade base URL (read in `cli.py:66`, `server.py:535`)
- `A2A_FACADE_API_KEY` — Bearer token (read in `cli.py:93`, `server.py:535`)

## Commits

1. `fix(transfers): use facade HTTP when A2A_BUS_URL is set (dispatch bug)`
2. `chore: bump version to 0.7.2`

## Tests

`tests/test_transfer_dispatch.py` — 5 new tests:
- Store + A2A_BUS_URL → `_facade_upload` called
- Store without A2A_BUS_URL → local `stage_file`
- HttpBusStore + A2A_BUS_URL → `_facade_upload` (priority over isinstance)
- Store + A2A_BUS_URL fetch → `_facade_download` called
- Store without A2A_BUS_URL fetch → local `load_manifest`

Full suite: **307 passed**, ruff ✓, mypy strict ✓