### PR TITLE
fix(transfers): rewrite locator URL using A2A_BUS_URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.7.3"
+version = "0.7.4"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/__init__.py
+++ b/src/a2a_mcp_bridge/__init__.py
@@ -1,3 +1,3 @@
 """a2a-mcp-bridge — MCP server for agent-to-agent messaging."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -786,7 +786,9 @@ def tool_agent_fetch_file(
     if bus_url:
         # --- v0.7.2: façade download when A2A_BUS_URL is set ---
         api_key = os.environ.get("A2A_FACADE_API_KEY", "")
-        download_url = f"{bus_url.rstrip('/')}/transfers/{transfer_id}"
+        download_url = _rewrite_transfer_url(
+            f"{bus_url.rstrip('/')}/transfers/{transfer_id}"
+        )
         tmp_dir = _tf.mkdtemp(prefix="a2a_fetch_")
 
         try:
@@ -908,6 +910,35 @@ def tool_agent_delete_file(
     except PermissionError as e:
         return {"error": {"code": "TRANSFER_ACL_DENIED", "message": str(e)}}
     return {"deleted": True, "transfer_id": transfer_id}
+
+
+def _rewrite_transfer_url(locator_url: str) -> str:
+    """Rewrite an http(s) locator URL to use the local ``A2A_BUS_URL`` host.
+
+    When the sender (VPS) embeds ``http://127.0.0.1:8080/transfers/abc``
+    in the locator, a remote (NAT'd) recipient cannot reach it.  If
+    ``A2A_BUS_URL`` is set, the scheme+netloc are replaced so the
+    recipient downloads from the correct host.
+
+    Non-http URLs (e.g. ``file:///...``) and cases where
+    ``A2A_BUS_URL`` is unset are returned unchanged.
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    bus_url = os.environ.get("A2A_BUS_URL", "").strip()
+    if not bus_url:
+        return locator_url
+
+    parsed_locator = urlparse(locator_url)
+    if parsed_locator.scheme not in ("http", "https"):
+        return locator_url
+
+    parsed_bus = urlparse(bus_url)
+    rewritten = parsed_locator._replace(
+        scheme=parsed_bus.scheme or parsed_locator.scheme,
+        netloc=parsed_bus.netloc or parsed_locator.netloc,
+    )
+    return urlunparse(rewritten)
 
 
 def _iso_utc(epoch_or_iso: float | str) -> str:

--- a/tests/test_transfer_dispatch.py
+++ b/tests/test_transfer_dispatch.py
@@ -975,3 +975,44 @@ def test_iso_utc_accepts_float() -> None:
     result = _iso_utc(1746230400.0)
     assert result.endswith("Z")
     assert "2025" in result or "2026" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #42 companion: _rewrite_transfer_url for cross-machine locator
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_transfer_url_localhost_to_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    """127.0.0.1 locator rewritten to A2A_BUS_URL host."""
+    from a2a_mcp_bridge.tools import _rewrite_transfer_url
+
+    monkeypatch.setenv("A2A_BUS_URL", "http://46.224.117.9:8080")
+    result = _rewrite_transfer_url("http://127.0.0.1:8080/transfers/abc-123")
+    assert result == "http://46.224.117.9:8080/transfers/abc-123"
+
+
+def test_rewrite_transfer_url_same_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Locator already points to A2A_BUS_URL host → unchanged."""
+    from a2a_mcp_bridge.tools import _rewrite_transfer_url
+
+    monkeypatch.setenv("A2A_BUS_URL", "http://46.224.117.9:8080")
+    result = _rewrite_transfer_url("http://46.224.117.9:8080/transfers/abc-123")
+    assert result == "http://46.224.117.9:8080/transfers/abc-123"
+
+
+def test_rewrite_transfer_url_file_scheme_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """file:// locator is never rewritten, even with A2A_BUS_URL set."""
+    from a2a_mcp_bridge.tools import _rewrite_transfer_url
+
+    monkeypatch.setenv("A2A_BUS_URL", "http://46.224.117.9:8080")
+    result = _rewrite_transfer_url("file:///tmp/a2a/transfers/abc-123/data.bin")
+    assert result == "file:///tmp/a2a/transfers/abc-123/data.bin"
+
+
+def test_rewrite_transfer_url_no_bus_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No A2A_BUS_URL → locator returned unchanged."""
+    from a2a_mcp_bridge.tools import _rewrite_transfer_url
+
+    monkeypatch.delenv("A2A_BUS_URL", raising=False)
+    result = _rewrite_transfer_url("http://127.0.0.1:8080/transfers/abc-123")
+    assert result == "http://127.0.0.1:8080/transfers/abc-123"


### PR DESCRIPTION
## Bug

`agent_fetch_file` receives a locator URL like `http://127.0.0.1:8080/transfers/<id>` from the VPS sender. On the Mac, 127.0.0.1 points to the Mac itself, not the VPS.

## Fix

New `_rewrite_transfer_url()` helper replaces the scheme+netloc of http(s) locator URLs with `A2A_BUS_URL` when set.

```
http://127.0.0.1:8080/transfers/abc → http://46.224.117.9:8080/transfers/abc
```

- http(s) locators: rewritten to A2A_BUS_URL host
- file:// locators: unchanged (same-machine)
- No A2A_BUS_URL: unchanged

## Tests (4 new)

| Scenario | A2A_BUS_URL | Input | Expected |
|---|---|---|---|
| localhost→public | `http://46.224.117.9:8080` | `http://127.0.0.1:8080/transfers/abc` | `http://46.224.117.9:8080/transfers/abc` |
| same host | `http://46.224.117.9:8080` | `http://46.224.117.9:8080/transfers/abc` | unchanged |
| file:// scheme | set | `file:///tmp/a2a/...` | unchanged |
| no A2A_BUS_URL | unset | `http://127.0.0.1:8080/...` | unchanged |

Closes #42 · v0.7.4