### PR TITLE
fix(transfers): send X-Agent-Id header in _facade_download for recipient ACL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.7.4"
+version = "0.7.5"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/__init__.py
+++ b/src/a2a_mcp_bridge/__init__.py
@@ -1,3 +1,3 @@
 """a2a-mcp-bridge — MCP server for agent-to-agent messaging."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/a2a_mcp_bridge/tools.py
+++ b/src/a2a_mcp_bridge/tools.py
@@ -444,6 +444,7 @@ def _facade_download(
     api_key: str,
     dest_dir: str,
     verify: bool = True,
+    agent_id: str = "",
 ) -> _FacadeDownloadResult:
     """Download a transfer file from the bus façade.
 
@@ -460,6 +461,9 @@ def _facade_download(
         dest_dir: Directory to write the file into (created if needed).
         verify: If True, verify sha256 against ``X-Transfer-SHA256``
             header when present.
+        agent_id: Caller's agent_id, sent as the ``X-Agent-Id`` header so
+            the façade can enforce recipient ACL. Empty string means
+            unauthenticated (will 403 on any recipient-ACL'd transfer).
 
     Returns:
         A :class:`_FacadeDownloadResult` with ``path``, ``sha256``,
@@ -475,9 +479,13 @@ def _facade_download(
     import urllib.error
     import urllib.request
 
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if agent_id:
+        headers["X-Agent-Id"] = agent_id
+
     req = urllib.request.Request(
         url,
-        headers={"Authorization": f"Bearer {api_key}"},
+        headers=headers,
     )
 
     try:
@@ -797,6 +805,7 @@ def tool_agent_fetch_file(
                 api_key=api_key,
                 dest_dir=tmp_dir,
                 verify=verify,
+                agent_id=caller_id,
             )
         except FileNotFoundError:
             return {"error": {"code": "TRANSFER_NOT_FOUND", "message": transfer_id}}

--- a/tests/test_transfer_dispatch.py
+++ b/tests/test_transfer_dispatch.py
@@ -305,6 +305,9 @@ def test_fetch_file_http_locator_with_bus_url(
         assert call_kwargs["url"] == "http://bus.test:8080/transfers/remote-fetch-tid"
         assert call_kwargs["api_key"] == "test-key-789"
         assert call_kwargs["verify"] is True
+        # Issue #44: caller_id must be forwarded as agent_id so the façade
+        # can enforce the recipient ACL on GET /transfers/<id>.
+        assert call_kwargs["agent_id"] == "bob"
 
     assert "error" not in result
     assert result["transfer_id"] == tid
@@ -1016,3 +1019,88 @@ def test_rewrite_transfer_url_no_bus_url(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.delenv("A2A_BUS_URL", raising=False)
     result = _rewrite_transfer_url("http://127.0.0.1:8080/transfers/abc-123")
     assert result == "http://127.0.0.1:8080/transfers/abc-123"
+
+
+# ---------------------------------------------------------------------------
+# Issue #44: _facade_download must send X-Agent-Id header so the façade
+# can enforce the recipient ACL on GET /transfers/<id>.
+# ---------------------------------------------------------------------------
+
+
+def test_facade_download_sends_x_agent_id_header(tmp_path: Path) -> None:
+    """When agent_id is provided, _facade_download sets the X-Agent-Id header
+    on the urllib Request, so the façade can match it against recipient_id.
+    """
+    content = b"tiny"
+    expected_sha = hashlib.sha256(content).hexdigest()
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="f.txt"',
+            "X-Transfer-SHA256": expected_sha,
+        }.get(key, default)
+    )
+    read_iter = iter([content, b""])
+    resp.read = lambda size=-1: next(read_iter, b"")
+    resp.close = MagicMock()
+
+    captured: dict = {}
+
+    def _fake_urlopen(req):
+        captured["headers"] = dict(req.headers)
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        _facade_download(
+            url="http://bus.test:8080/transfers/tid-xyz",
+            api_key="key-abc",
+            dest_dir=str(tmp_path / "dl"),
+            verify=True,
+            agent_id="vlbeau-macqwen36",
+        )
+
+    # urllib normalises header keys to Title-Case.
+    assert captured["headers"].get("Authorization") == "Bearer key-abc"
+    assert captured["headers"].get("X-agent-id") == "vlbeau-macqwen36"
+
+
+def test_facade_download_omits_x_agent_id_when_empty(tmp_path: Path) -> None:
+    """When agent_id='' (default), the X-Agent-Id header is NOT emitted.
+
+    Preserves backward compatibility for any caller that relied on the
+    old signature (no recipient-ACL transfers).
+    """
+    content = b"tiny"
+    expected_sha = hashlib.sha256(content).hexdigest()
+
+    resp = MagicMock()
+    resp.headers = MagicMock()
+    resp.headers.get = MagicMock(
+        side_effect=lambda key, default="": {
+            "Content-Disposition": 'attachment; filename="f.txt"',
+            "X-Transfer-SHA256": expected_sha,
+        }.get(key, default)
+    )
+    read_iter = iter([content, b""])
+    resp.read = lambda size=-1: next(read_iter, b"")
+    resp.close = MagicMock()
+
+    captured: dict = {}
+
+    def _fake_urlopen(req):
+        captured["headers"] = dict(req.headers)
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        _facade_download(
+            url="http://bus.test:8080/transfers/tid-xyz",
+            api_key="key-abc",
+            dest_dir=str(tmp_path / "dl"),
+            verify=True,
+            # agent_id omitted -> default ""
+        )
+
+    assert captured["headers"].get("Authorization") == "Bearer key-abc"
+    assert "X-agent-id" not in captured["headers"]


### PR DESCRIPTION
## Bug

Companion to #43. With `A2A_BUS_URL` set, `agent_fetch_file` → `_facade_download` (stdlib urllib), which sent only `Authorization: Bearer`. The façade's `GET /transfers/<id>` requires `X-Agent-Id` to match `recipient_id`, so every cross-host fetch returned **403 Forbidden**.

## Fix

- `_facade_download` gains an `agent_id: str = ""` parameter
- When non-empty, sets `X-Agent-Id: <agent_id>` on the urllib Request
- `tool_agent_fetch_file` forwards `caller_id`
- Default `""` preserves backward compat for unauthenticated paths

## Tests (3)

| Scenario | Expected |
|---|---|
| `tool_agent_fetch_file(caller_id='bob')` with `A2A_BUS_URL` set | `_facade_download` called with `agent_id='bob'` |
| `_facade_download(agent_id='vlbeau-macqwen36')` | urllib Request has `X-Agent-Id` header |
| `_facade_download()` with default | no `X-Agent-Id` header |

Also: 1 existing dispatch test was extended to assert the new kwarg.

## Verified

- 342/342 tests green
- ruff clean
- End-to-end validated: #43 rewrite worked (request reached 62.34.73.185 → VPS public IP), only the façade ACL blocked the fetch.

Closes #44 · v0.7.5