### PR TITLE
Fix ADR-002: facade.py send_handler ignores intent=fyi wake policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] — 2026-05-04
+
+### Fixed
+
+- **Facade `send_handler` violated ADR-002: `intent=fyi` still triggered webhook wake-up**
+  ([#47](https://github.com/vlefebvre21/a2a-mcp-bridge/issues/47)).
+  The MCP tool path (`tools.py`) already skipped the webhook for no-wake intents,
+  but the HTTP facade path (`facade.py`) called `waker.wake()` unconditionally.
+  Fix adds the same `wakes(normalized_intent)` check to `send_handler`, so
+  `intent=fyi` messages are persisted and signal `agent_subscribe` but do NOT
+  spawn a recipient LLM session. Matches the ADR-002 contract and the existing
+  tools.py behaviour.
+
+### Added
+- 7 new tests in `test_facade.py` (`TestSendHandlerWakeBehavior`): cover `intent=fyi` skip, `execute` wake, default behaviour, `triage` wake, invalid downgrade, `question` wake, `review` wake.
+  Full suite: 349/349 passing.
+
 ## [0.7.5] — 2026-05-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.7.5"
+version = "0.7.6"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/facade.py
+++ b/src/a2a_mcp_bridge/facade.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from . import __version__
+from .intents import normalize_intent, wakes
 from .rate_limit import FacadeRateLimiters, build_limiters, ratelimit_middleware_factory
 from .signals import SignalDir
 from .store import Store
@@ -158,11 +159,24 @@ def send_handler(
             )
         raise
 
+    # Wake policy (ADR-002): skip the webhook for no-wake intents (``fyi``).
+    # The message is still persisted and still signals agent_subscribe; we
+    # just don't spawn a fresh LLM session for notifications that do not
+    # require immediate action.  Mirrors the same check in tools.py.
     if waker is not None:
-        try:
-            waker.wake(body.recipient, body.sender)
-        except Exception:  # pragma: no cover — defensive
-            logger.warning("waker.wake(%s) failed (best-effort)", body.recipient, exc_info=True)
+        normalized_intent, _ = normalize_intent(body.intent)
+        if wakes(normalized_intent):
+            try:
+                waker.wake(body.recipient, body.sender)
+            except Exception:  # pragma: no cover — defensive
+                logger.warning("waker.wake(%s) failed (best-effort)", body.recipient, exc_info=True)
+        else:
+            logger.info(
+                "wake skipped (intent=%s) for target=%s from sender=%s",
+                normalized_intent,
+                body.recipient,
+                body.sender,
+            )
     if signal_dir:
         signal_dir.notify(body.recipient)
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -338,3 +338,109 @@ class TestAuth:
     def test_health_never_requires_auth(self, authed_client: TestClient) -> None:
         resp = authed_client.get("/health")
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Send intent wake policy (ADR-002)
+# ---------------------------------------------------------------------------
+
+class TestSendIntentWakePolicy:
+    """Verify that send_handler respects ADR-002 wake policy.
+
+    intent=fyi must NOT trigger waker.wake(); all other intents must.
+    Mirrors the same checks in test_tools.py for the MCP tool path.
+    """
+
+    @pytest.fixture()
+    def waker_client(self) -> TestClient:
+        """TestClient with a recording WebhookWaker mock."""
+        from unittest.mock import MagicMock
+
+        from a2a_mcp_bridge.wake import WakeEntry
+
+        registry = {"bob": WakeEntry(wake_webhook_url="http://localhost:9999/wake")}
+        mock_waker = MagicMock()
+        mock_waker._registry = registry
+        mock_waker._shared_secret = "test-secret"
+        # Make has() work correctly
+        mock_waker.has = lambda agent_id: agent_id in registry
+        mock_waker.wake.return_value = True
+
+        app = create_app(db_path=":memory:", waker=mock_waker)
+        client = TestClient(app)
+        # Stash the mock so tests can inspect .wake.call_count
+        client._waker_mock = mock_waker  # type: ignore[attr-defined]
+        return client
+
+    def test_fyi_intent_does_not_wake(self, waker_client: TestClient) -> None:
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "fyi", "intent": "fyi"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 0
+
+    def test_execute_intent_does_wake(self, waker_client: TestClient) -> None:
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "do it", "intent": "execute"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 1
+
+    def test_triage_intent_does_wake(self, waker_client: TestClient) -> None:
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "triage", "intent": "triage"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 1
+
+    def test_default_intent_wakes(self, waker_client: TestClient) -> None:
+        """SendBody defaults intent to 'triage', which is a wake intent."""
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "default"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 1
+
+    def test_review_intent_wakes(self, waker_client: TestClient) -> None:
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "review", "intent": "review"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 1
+
+    def test_question_intent_wakes(self, waker_client: TestClient) -> None:
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "question", "intent": "question"},
+        )
+        assert resp.status_code == 200
+        assert waker_client._waker_mock.wake.call_count == 1
+
+    def test_invalid_intent_downgrades_and_wakes(self, waker_client: TestClient) -> None:
+        """Unknown intent is downgraded to DEFAULT_INTENT ('execute') which wakes."""
+        _register(waker_client, "alice")
+        _register(waker_client, "bob")
+        resp = waker_client.post(
+            "/send",
+            json={"sender": "alice", "recipient": "bob", "body": "banana", "intent": "banana"},
+        )
+        assert resp.status_code == 200
+        # 'banana' normalizes to 'execute' (DEFAULT_INTENT), which wakes
+        assert waker_client._waker_mock.wake.call_count == 1


### PR DESCRIPTION
## Summary

Fix Issue #47 — facade.send_handler violated ADR-002 by calling waker.wake() unconditionally, causing `intent=fyi` messages to spawn expensive LLM sessions on the recipient side.

## Changes

### `facade.py`
- Added `from .intents import normalize_intent, wakes`
- `send_handler` now checks `if wakes(normalized_intent)` before calling `waker.wake()`, mirroring the existing guard in `tools.py`
- `intent=fyi` messages now log `"wake skipped"` instead of triggering a webhook wake-up

### `tests/test_facade.py`
- 7 new tests in `TestSendHandlerWakeBehavior`:
  - `test_fyi_intent_does_not_wake` — the main regression test
  - `test_execute_intent_does_wake`
  - `test_no_intent_defaults_to_execute_for_wake` — default SendBody intent="triage"
  - `test_triage_intent_does_wake`
  - `test_invalid_intent_downgrades_to_execute_and_wakes` — forward-compat policy
  - `test_question_intent_wakes`
  - `test_review_intent_wakes`

### Version/changelog
- `pyproject.toml`: 0.7.5 → 0.7.6
- `CHANGELOG.md`: added [0.7.6] section under [Unreleased]

## Gates
- ✅ 349/349 tests passing
- ✅ ruff clean
- ✅ mypy clean