### PR TITLE
Capability Registry — v1 review fixes (C1, C3, M2, M3, M4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,39 @@ and SQLite-backed.
 
 ## What it does
 
-Six MCP tools, all stable since v0.5:
+Six core MCP tools (stable since v0.5) plus five Capability Registry tools
+(introduced in v0.8.0):
 
-| Tool | Description |
-|---|---|
-| `agent_send(target, message, metadata=None)` | Drop a message in another agent's inbox. Returns a `message_id`. Fires a real-time signal and an optional HTTP webhook wake-up toward the recipient. |
-| `agent_inbox(limit=10, unread_only=True)` | Read messages addressed to the calling agent. Atomically marks them as read when `unread_only=True`. |
-| `agent_inbox_peek(since_ts=None, limit=50)` | Read-only inbox view — no mark-as-read. Safe for concurrent sessions to inspect the inbox without consuming messages. |
-| `agent_list(active_within_days=7)` | List agents seen on the bus in the given window, with their capabilities and last-seen timestamps. |
-| `agent_subscribe(timeout_seconds=30, limit=10)` | Long-poll primitive: blocks up to `timeout_seconds` (server-capped at 55 s) waiting for new messages. Returns instantly if messages are already pending. |
-| `agent_ping()` | Returns `{"server", "version", "agent_id"}`. Useful to detect a stale stdio child after a bridge upgrade. |
+**Core messaging tools:**
+
+- `agent_send(target, message, metadata=None)` — Drop a message in another
+  agent's inbox. Returns a `message_id`. Fires a real-time signal and an
+  optional HTTP webhook wake-up toward the recipient.
+- `agent_inbox(limit=10, unread_only=True)` — Read messages addressed to the
+  calling agent. Atomically marks them as read when `unread_only=True`.
+- `agent_inbox_peek(since_ts=None, limit=50)` — Read-only inbox view — no
+  mark-as-read. Safe for concurrent sessions to inspect the inbox without
+  consuming messages.
+- `agent_list(active_within_days=7)` — List agents seen on the bus in the
+  given window, with their capabilities and last-seen timestamps.
+- `agent_subscribe(timeout_seconds=30, limit=10)` — Long-poll primitive:
+  blocks up to `timeout_seconds` (server-capped at 55 s) waiting for new
+  messages. Returns instantly if messages are already pending.
+- `agent_ping()` — Returns `{"server", "version", "agent_id"}`. Useful to
+  detect a stale stdio child after a bridge upgrade.
+
+**Capability Registry tools:**
+
+- `capability_announce(payload)` — Register or update an agent's
+  capabilities in the registry.
+- `capability_query(keyword, max_cost)` — Query agents by keyword and/or
+  cost ceiling.
+- `capability_discover()` — List all available capabilities across all
+  registered agents.
+- `capability_find_best(skill, max_cost)` — Find the best-matching agents
+  for a specific skill keyword (scored).
+- `capability_ping(agent_id)` — Signal that an agent is still alive
+  (heartbeat ping).
 
 Backed by SQLite by default (zero-dep, single file). For remote/distributed
 setups, an optional HTTP facade (`serve-facade`) exposes the bus over REST —
@@ -861,6 +884,122 @@ a2a-mcp-bridge wake-registry init # build the webhook wake registry from ~/.herm
 | `--signal-dir` / `A2A_SIGNAL_DIR` | `/tmp/a2a-signals` | Signal directory for `subscribe` wake-ups. |
 | `--wake-registry` / `A2A_WAKE_REGISTRY` | `~/.a2a-wake-registry.json` | Webhook wake registry path. |
 
+## Capability Registry
+
+The Capability Registry provides **centralized discovery of Hermes agent
+capabilities** on the bus. Instead of guessing which agent can do what, an
+agent announces its skills at startup; any other agent can then query,
+discover, or find the best match for a task — all through MCP tools.
+
+### Architecture
+
+The registry lives in `src/a2a_mcp_bridge/registry/` with five modules:
+
+- **`models.py`** — Pydantic models (`AgentInfo`, `Capability`, `CostModel`)
+  that define the schema for registered agents and their skills.
+- **`storage.py`** — `RegistryStorage`: SQLite persistence layer. Creates a
+  `registry.db` co-located with the main bus database; tables are `agents`
+  and `capabilities` with JSON-serialised capability payloads.
+- **`manager.py`** — `CapabilityRegistry`: main in-memory cache + write-through
+  to SQLite. Handles `announce()` (register/update) and `query()` (keyword +
+  cost filtering).
+- **`query.py`** — `RegistryQuery`: higher-level discovery helpers.
+  `discover_all()` flattens every capability across every agent into a
+  clean dict list; `find_best()` scores matches (keyword hit → 1.0, cost
+  penalty → 0.5) and sorts by score descending, then cost ascending.
+- **`heartbeat.py`** — `HeartbeatManager`: async background loop that tracks
+  agent liveness. Agents call `capability_ping()` to signal they are still
+  alive; if no heartbeat is received within **2× the interval** (default 60 s),
+  the agent is marked `offline` and persisted to DB.
+
+### MCP tools
+
+Five new tools are registered alongside the core six:
+
+- **`capability_announce(payload)`** — Register or update an agent's
+  capabilities. `payload` is a JSON string matching the `AgentInfo` model.
+  Returns `{"status": "ok", "registered": <count>}`.
+- **`capability_query(keyword="", max_cost=None)`** — Filter online agents by
+  keyword (matches `skill_id`, `description`, `domain`) and/or a monetary
+  cost ceiling. Returns a list of matching `AgentInfo` objects with enriched
+  fields (`max_context_tokens`, `version`, `agent_name`, `description`).
+- **`capability_discover()`** — List *every* capability across all registered
+  agents in a flat format suitable for A2A/MCP consumption. Response includes
+  a timestamp and `total_agents` count.
+- **`capability_find_best(skill, max_cost=None)`** — Scored search for the
+  best agent for a given skill keyword. Results are sorted by score
+  (descending) then token cost (ascending).
+- **`capability_ping(agent_id)`** — Heartbeat ping. Signals that the agent is
+  still alive. The `HeartbeatManager` marks agents as `offline` if no ping
+  arrives within twice the heartbeat interval.
+
+### Pydantic models
+
+- **`CostModel`** — `tokens_per_call` (float), `latency_ms` (int),
+  `monetary_cost_usd` (optional float), `type` (literal:
+  `"local"` | `"api"` | `"hybrid"`).
+- **`Capability`** — `skill_id`, `description`, `domain`,
+  `parameters_schema`, `return_schema`, `cost` (CostModel),
+  `supports_streaming`, `max_context_tokens`, `permissions`, `version`.
+- **`AgentInfo`** — `agent_id`, `name`, `capabilities` (list of Capability),
+  `status` (`"online"` | `"offline"` | `"degraded"`), `last_heartbeat`,
+  `metadata`.
+
+### Heartbeat mechanism
+
+The `HeartbeatManager` runs an async background loop (default interval:
+30 seconds). On each tick it checks which agents have not sent a
+`capability_ping()` within **2× the interval** (60 s by default). Stale
+agents are marked `offline` and the status change is persisted to SQLite.
+The manager is wired into the MCP server lifecycle (`on_startup` /
+`on_shutdown`), so it starts and stops automatically with the bridge.
+
+### SQLite persistence
+
+Registry data is stored in `registry.db`, co-located with the main
+`a2a-bus.sqlite` database. Two tables are created automatically:
+
+- **`agents`** — `agent_id` (PK), `name`, `status`, `last_heartbeat`,
+  `metadata` (JSON).
+- **`capabilities`** — `id` (auto-increment PK), `agent_id` (FK → agents),
+  `skill_id`, `capability_json` (full serialised `Capability` model).
+
+On startup, the `CapabilityRegistry` warms its in-memory cache from
+`registry.db`, so registrations survive restarts.
+
+### Quick usage example
+
+```python
+# 1. Announce an agent with two capabilities
+capability_announce(payload=json.dumps({
+    "agent_id": "research-agent",
+    "name": "Research Agent",
+    "capabilities": [
+        {
+            "skill_id": "web-search",
+            "description": "Search the web and summarise results",
+            "domain": "research",
+            "cost": {"tokens_per_call": 500, "latency_ms": 2000, "type": "api"}
+        },
+        {
+            "skill_id": "pdf-summarise",
+            "description": "Summarise PDF documents",
+            "domain": "research",
+            "cost": {"tokens_per_call": 1000, "latency_ms": 3000, "type": "local"}
+        }
+    ]
+}))
+# → {"status": "ok", "registered": 2}
+
+# 2. Query by keyword
+capability_query(keyword="search")
+# → [AgentInfo for research-agent, ...]
+
+# 3. Discover everything on the bus
+capability_discover()
+# → {"status": "success", "capabilities": [...], "total_agents": 1, ...}
+```
+
 ## Roadmap
 
 Shipped so far:
@@ -903,6 +1042,12 @@ Planned:
   can participate. Optional Bearer token auth, Pydantic validation,
   async subscribe, webhook wake-up forwarding.
   See [ADR-006.1](docs/adr/ADR-006.1-http-bus-facade.md).
+- **v0.8.0** — Capability Registry. Five new MCP tools
+  (`capability_announce`, `capability_query`, `capability_discover`,
+  `capability_find_best`, `capability_ping`) for centralized discovery of
+  Hermes agent capabilities. Pydantic models (`AgentInfo`, `Capability`,
+  `CostModel`), SQLite-backed persistence (`registry.db`), async heartbeat
+  monitor with stale-agent cleanup.
 
 Planned:
 

--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ a2a-mcp-bridge register --all --hermes-profiles ~/.hermes/profiles
 | `A2A_TRANSFER_MAX_TTL_SECONDS` | `604800` | Hard cap on any transfer TTL (7 d). |
 | `A2A_TRANSFER_MAX_SIZE_BYTES` | `104857600` | Max file size per transfer (100 MB). |
 | `A2A_TRANSFER_MAX_PENDING_PER_AGENT` | `50` | Max un-expired transfers a single sender may have open. |
+| `A2A_HEARTBEAT_INTERVAL` | `30` | Heartbeat check interval in seconds. Agents not seen for 2x this value are marked offline. |
 
 ## HTTP Facade (Remote Mode)
 

--- a/examples/hermes_agent_client.py
+++ b/examples/hermes_agent_client.py
@@ -1,0 +1,116 @@
+"""Example: Hermes Agent Client with Announcement + Heartbeat.
+
+This demonstrates how a specialized Hermes agent announces its capabilities
+to the a2a-mcp-bridge and sends periodic heartbeat pings so the registry
+knows it is still alive.
+
+Usage:
+    python -m examples.hermes_agent_client
+
+Adapt ``bridge_client.send_announce()`` and ``bridge_client.send_heartbeat()``
+to your actual A2A/MCP client implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+
+logger = logging.getLogger(__name__)
+
+
+class HermesAgentClient:
+    """Example client for a specialized Hermes agent."""
+
+    def __init__(self, bridge_client: Any, agent_id: str, name: str) -> None:
+        self.bridge_client = bridge_client  # your A2A/MCP client
+        self.agent_info = AgentInfo(
+            agent_id=agent_id,
+            name=name,
+            capabilities=self._define_capabilities(),
+            status="online",
+        )
+        self._heartbeat_task: asyncio.Task | None = None
+
+    def _define_capabilities(self) -> list[Capability]:
+        """Define what this specialized agent can do."""
+        return [
+            Capability(
+                skill_id="code-review-python",
+                description="Performs high-quality Python code reviews with security and performance focus",
+                domain="code",
+                cost=CostModel(tokens_per_call=120.0, latency_ms=650, type="local"),
+                supports_streaming=True,
+                max_context_tokens=128000,
+                permissions=["read", "analyze"],
+            ),
+            Capability(
+                skill_id="diagram-generation",
+                description="Generates architecture and flow diagrams",
+                domain="creative",
+                cost=CostModel(tokens_per_call=80.0, latency_ms=400, type="local"),
+                supports_streaming=False,
+            ),
+        ]
+
+    async def start(self) -> None:
+        """Announce capabilities and start heartbeat."""
+        # 1. Announce to the bridge
+        await self.bridge_client.send_announce(self.agent_info.model_dump())
+        logger.info("%s: announced capabilities to bridge", self.agent_info.name)
+
+        # 2. Start periodic heartbeat
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        logger.info("%s: heartbeat started", self.agent_info.name)
+
+    async def _heartbeat_loop(self) -> None:
+        """Send heartbeat every 20 seconds."""
+        while True:
+            try:
+                self.bridge_client.send_heartbeat(self.agent_info.agent_id)
+                await asyncio.sleep(20)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("%s: heartbeat error", self.agent_info.name)
+                await asyncio.sleep(5)
+
+    async def stop(self) -> None:
+        """Graceful shutdown."""
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._heartbeat_task = None
+        logger.info("%s: shutdown complete", self.agent_info.name)
+
+
+# ---------------------------------------------------------------------------
+# Usage example
+# ---------------------------------------------------------------------------
+
+async def main() -> None:
+    """Run the demo agent for 5 minutes."""
+    # Assume you have a bridge_client already connected
+    # bridge_client = your_a2a_mcp_client(...)
+
+    # agent = HermesAgentClient(
+    #     bridge_client=bridge_client,
+    #     agent_id="hermes-python-specialist-01",
+    #     name="Python Specialist",
+    # )
+    # await agent.start()
+    # try:
+    #     await asyncio.sleep(300)  # demo: run for 5 minutes
+    # finally:
+    #     await agent.stop()
+    print("See docstring at the top of this file for usage instructions.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/a2a_mcp_bridge/cli.py
+++ b/src/a2a_mcp_bridge/cli.py
@@ -14,6 +14,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from .registry.manager import CapabilityRegistry
+from .registry.query import RegistryQuery
 from .server import main as server_main
 from .store import Store
 
@@ -32,9 +34,11 @@ app = typer.Typer(
 agents_app = typer.Typer(help="Manage and inspect agents.")
 messages_app = typer.Typer(help="Inspect messages.")
 wake_registry_app = typer.Typer(help="Manage the webhook wake-up registry.")
+registry_app = typer.Typer(help="Query the Capability Registry.")
 app.add_typer(agents_app, name="agents")
 app.add_typer(messages_app, name="messages")
 app.add_typer(wake_registry_app, name="wake-registry")
+app.add_typer(registry_app, name="registry")
 
 console = Console()
 DEFAULT_DB = "~/.a2a-bus.sqlite"
@@ -533,6 +537,101 @@ def wake_registry_init(
             f"[yellow]skipped agents with mismatching webhook secrets:[/yellow] "
             f"{', '.join(skipped_mismatch)}"
         )
+
+
+# ── Capability Registry commands ────────────────────────────────────
+
+DEFAULT_REGISTRY_DB = "~/.a2a-registry.db"
+
+
+@registry_app.command("discover")
+def registry_discover(
+    db: str = typer.Option(DEFAULT_REGISTRY_DB, help="Path to registry SQLite database."),
+) -> None:
+    """List all capabilities across all registered agents."""
+    registry = CapabilityRegistry(_expand(db))
+    query = RegistryQuery(registry)
+    capabilities = query.discover_all()
+    if not capabilities:
+        console.print("[yellow]No capabilities registered[/yellow]")
+        return
+    table = Table(title="Registered Capabilities")
+    table.add_column("agent_id")
+    table.add_column("agent_name")
+    table.add_column("skill_id")
+    table.add_column("domain")
+    table.add_column("tokens/call")
+    table.add_column("status")
+    for cap in capabilities:
+        # agent status is not in discover_all output; fetch from registry
+        agent = registry.get_agent(cap["agent_id"])
+        status = agent.status if agent else "?"
+        table.add_row(
+            cap["agent_id"],
+            cap["agent_name"],
+            cap["skill_id"],
+            cap["domain"],
+            str(cap["cost"]["tokens_per_call"]),
+            status,
+        )
+    console.print(table)
+
+
+@registry_app.command("list-agents")
+def registry_list_agents(
+    db: str = typer.Option(DEFAULT_REGISTRY_DB, help="Path to registry SQLite database."),
+) -> None:
+    """List all registered agents with their status and skill count."""
+    registry = CapabilityRegistry(_expand(db))
+    agents = registry.get_all_agents()
+    if not agents:
+        console.print("[yellow]No agents registered[/yellow]")
+        return
+    table = Table(title="Registered Agents")
+    table.add_column("agent_id")
+    table.add_column("name")
+    table.add_column("status")
+    table.add_column("capabilities")
+    table.add_column("last_heartbeat")
+    for a in agents:
+        table.add_row(
+            a.agent_id,
+            a.name,
+            a.status,
+            str(len(a.capabilities)),
+            a.last_heartbeat.isoformat(),
+        )
+    console.print(table)
+
+
+@registry_app.command("find-best")
+def registry_find_best(
+    skill: str = typer.Argument(help="Skill keyword to search for."),
+    max_cost: float = typer.Option(None, help="Maximum token cost ceiling."),
+    db: str = typer.Option(DEFAULT_REGISTRY_DB, help="Path to registry SQLite database."),
+) -> None:
+    """Find the best matching agents for a skill keyword."""
+    registry = CapabilityRegistry(_expand(db))
+    query = RegistryQuery(registry)
+    results = query.find_best(skill, max_cost=max_cost)
+    if not results:
+        console.print(f"[yellow]No matching agents for '{skill}'[/yellow]")
+        return
+    table = Table(title=f"Best matches for '{skill}'")
+    table.add_column("agent_id")
+    table.add_column("agent_name")
+    table.add_column("skill_id")
+    table.add_column("score")
+    table.add_column("tokens/call")
+    for r in results:
+        table.add_row(
+            r["agent_id"],
+            r["agent_name"],
+            r["skill_id"],
+            f"{r['score']:.1f}",
+            str(r["cost_tokens"]),
+        )
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/src/a2a_mcp_bridge/cli.py
+++ b/src/a2a_mcp_bridge/cli.py
@@ -541,7 +541,7 @@ def wake_registry_init(
 
 # ── Capability Registry commands ────────────────────────────────────
 
-DEFAULT_REGISTRY_DB = "~/.a2a-registry.db"
+DEFAULT_REGISTRY_DB = "~/.a2a-bus.registry.db"
 
 
 @registry_app.command("discover")

--- a/src/a2a_mcp_bridge/registry/__init__.py
+++ b/src/a2a_mcp_bridge/registry/__init__.py
@@ -6,10 +6,10 @@ from .models import AgentInfo, Capability, CostModel
 from .query import RegistryQuery
 
 __all__ = [
-    "CapabilityRegistry",
-    "HeartbeatManager",
     "AgentInfo",
     "Capability",
+    "CapabilityRegistry",
     "CostModel",
+    "HeartbeatManager",
     "RegistryQuery",
 ]

--- a/src/a2a_mcp_bridge/registry/__init__.py
+++ b/src/a2a_mcp_bridge/registry/__init__.py
@@ -1,0 +1,6 @@
+"""Capability Registry for Hermes Agents."""
+
+from .manager import CapabilityRegistry
+from .models import AgentInfo, Capability, CostModel
+
+__all__ = ["CapabilityRegistry", "AgentInfo", "Capability", "CostModel"]

--- a/src/a2a_mcp_bridge/registry/__init__.py
+++ b/src/a2a_mcp_bridge/registry/__init__.py
@@ -1,7 +1,15 @@
 """Capability Registry for Hermes Agents."""
 
+from .heartbeat import HeartbeatManager
 from .manager import CapabilityRegistry
 from .models import AgentInfo, Capability, CostModel
 from .query import RegistryQuery
 
-__all__ = ["CapabilityRegistry", "AgentInfo", "Capability", "CostModel", "RegistryQuery"]
+__all__ = [
+    "CapabilityRegistry",
+    "HeartbeatManager",
+    "AgentInfo",
+    "Capability",
+    "CostModel",
+    "RegistryQuery",
+]

--- a/src/a2a_mcp_bridge/registry/__init__.py
+++ b/src/a2a_mcp_bridge/registry/__init__.py
@@ -2,5 +2,6 @@
 
 from .manager import CapabilityRegistry
 from .models import AgentInfo, Capability, CostModel
+from .query import RegistryQuery
 
-__all__ = ["CapabilityRegistry", "AgentInfo", "Capability", "CostModel"]
+__all__ = ["CapabilityRegistry", "AgentInfo", "Capability", "CostModel", "RegistryQuery"]

--- a/src/a2a_mcp_bridge/registry/heartbeat.py
+++ b/src/a2a_mcp_bridge/registry/heartbeat.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from datetime import datetime
-from typing import Dict
 
 from .manager import CapabilityRegistry
 
@@ -19,7 +19,7 @@ class HeartbeatManager:
     def __init__(self, registry: CapabilityRegistry, interval_seconds: int = 30) -> None:
         self.registry = registry
         self.interval = interval_seconds
-        self._last_heartbeat: Dict[str, float] = {}
+        self._last_heartbeat: dict[str, float] = {}
         self._running = False
         self._task: asyncio.Task | None = None
 
@@ -38,10 +38,8 @@ class HeartbeatManager:
         self._running = False
         if self._task is not None:
             self._task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._task
-            except asyncio.CancelledError:
-                pass
             self._task = None
         logger.info("Heartbeat monitor stopped")
 
@@ -67,7 +65,7 @@ class HeartbeatManager:
                 await asyncio.sleep(5)
 
     def _cleanup_stale_agents(self) -> None:
-        """Mark agents as offline if no heartbeat for > 2×interval."""
+        """Mark agents as offline if no heartbeat for > 2x interval."""
         now = time.time()
         threshold = now - (self.interval * 2)
 

--- a/src/a2a_mcp_bridge/registry/heartbeat.py
+++ b/src/a2a_mcp_bridge/registry/heartbeat.py
@@ -1,0 +1,80 @@
+"""Heartbeat and live status management for registered agents."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import Dict
+
+from .manager import CapabilityRegistry
+
+logger = logging.getLogger("a2a_mcp_bridge.registry.heartbeat")
+
+
+class HeartbeatManager:
+    """Manages periodic heartbeats and agent status updates."""
+
+    def __init__(self, registry: CapabilityRegistry, interval_seconds: int = 30) -> None:
+        self.registry = registry
+        self.interval = interval_seconds
+        self._last_heartbeat: Dict[str, float] = {}
+        self._running = False
+        self._task: asyncio.Task | None = None
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Start the heartbeat monitoring task."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._heartbeat_loop())
+        logger.info("Heartbeat monitor started (interval=%ds)", self.interval)
+
+    async def stop(self) -> None:
+        """Stop the heartbeat task."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Heartbeat monitor stopped")
+
+    # ── heartbeat API ──────────────────────────────────────────────────
+
+    def ping(self, agent_id: str) -> None:
+        """Called by agents to signal they are still alive."""
+        self._last_heartbeat[agent_id] = time.time()
+        logger.debug("Agent %s pinged at %s", agent_id, datetime.utcnow().isoformat())
+
+    # ── internal ───────────────────────────────────────────────────────
+
+    async def _heartbeat_loop(self) -> None:
+        """Background loop that cleans up stale agents."""
+        while self._running:
+            try:
+                await asyncio.sleep(self.interval)
+                self._cleanup_stale_agents()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("Error in heartbeat loop")
+                await asyncio.sleep(5)
+
+    def _cleanup_stale_agents(self) -> None:
+        """Mark agents as offline if no heartbeat for > 2×interval."""
+        now = time.time()
+        threshold = now - (self.interval * 2)
+
+        for agent_id, last_time in list(self._last_heartbeat.items()):
+            if last_time < threshold:
+                agent = self.registry.get_agent(agent_id)
+                if agent and agent.status != "offline":
+                    logger.warning("Agent %s marked as offline (stale heartbeat)", agent_id)
+                    agent.status = "offline"
+                    self.registry.announce(agent)  # persist to DB + cache

--- a/src/a2a_mcp_bridge/registry/heartbeat.py
+++ b/src/a2a_mcp_bridge/registry/heartbeat.py
@@ -21,7 +21,7 @@ class HeartbeatManager:
         self.interval = interval_seconds
         self._last_heartbeat: dict[str, float] = {}
         self._running = False
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[None] | None = None
 
     # ── lifecycle ──────────────────────────────────────────────────────
 

--- a/src/a2a_mcp_bridge/registry/heartbeat.py
+++ b/src/a2a_mcp_bridge/registry/heartbeat.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 
 from .manager import CapabilityRegistry
 
@@ -48,7 +48,7 @@ class HeartbeatManager:
     def ping(self, agent_id: str) -> None:
         """Called by agents to signal they are still alive."""
         self._last_heartbeat[agent_id] = time.time()
-        logger.debug("Agent %s pinged at %s", agent_id, datetime.utcnow().isoformat())
+        logger.debug("Agent %s pinged at %s", agent_id, datetime.now(UTC).isoformat())
 
     # ── internal ───────────────────────────────────────────────────────
 

--- a/src/a2a_mcp_bridge/registry/manager.py
+++ b/src/a2a_mcp_bridge/registry/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 
 from .models import AgentInfo
 from .storage import RegistryStorage
@@ -11,11 +12,20 @@ logger = logging.getLogger("a2a_mcp_bridge.registry")
 
 
 class CapabilityRegistry:
-    """Central registry for Hermes agent capabilities."""
+    """Central registry for Hermes agent capabilities.
+
+    Thread-safety: ``_cache`` is protected by an ``RLock``. The lock
+    guards every mutation (``announce``) and every read
+    (``query`` / ``get_agent`` / ``get_all_agents``). This prevents
+    ``RuntimeError: dictionary changed size during iteration`` when
+    :class:`HeartbeatManager._cleanup_stale_agents` mutates the cache
+    from a background task while an MCP tool call is iterating it.
+    """
 
     def __init__(self, db_path: str = "registry.db") -> None:
         self.storage = RegistryStorage(db_path)
         self._cache: dict[str, AgentInfo] = {}
+        self._lock = threading.RLock()
         # Warm cache from persistent storage
         for agent in self.storage.get_all_agents():
             self._cache[agent.agent_id] = agent
@@ -25,7 +35,8 @@ class CapabilityRegistry:
     def announce(self, agent: AgentInfo) -> None:
         """Register a new agent or update its capabilities."""
         self.storage.register_agent(agent)
-        self._cache[agent.agent_id] = agent
+        with self._lock:
+            self._cache[agent.agent_id] = agent
         logger.info(
             "Agent %r registered with %d capabilities",
             agent.name,
@@ -39,7 +50,8 @@ class CapabilityRegistry:
 
         For now this is a simple filter — can be enhanced with scoring later.
         """
-        agents = list(self._cache.values())
+        with self._lock:
+            agents = list(self._cache.values())
 
         # Filter by status
         agents = [a for a in agents if a.status == "online"]
@@ -73,8 +85,10 @@ class CapabilityRegistry:
 
     def get_agent(self, agent_id: str) -> AgentInfo | None:
         """Return cached agent info (or None)."""
-        return self._cache.get(agent_id)
+        with self._lock:
+            return self._cache.get(agent_id)
 
     def get_all_agents(self) -> list[AgentInfo]:
         """Return all cached agents."""
-        return list(self._cache.values())
+        with self._lock:
+            return list(self._cache.values())

--- a/src/a2a_mcp_bridge/registry/manager.py
+++ b/src/a2a_mcp_bridge/registry/manager.py
@@ -75,3 +75,7 @@ class CapabilityRegistry:
     def get_agent(self, agent_id: str) -> Optional[AgentInfo]:
         """Return cached agent info (or None)."""
         return self._cache.get(agent_id)
+
+    def get_all_agents(self) -> List[AgentInfo]:
+        """Return all cached agents."""
+        return list(self._cache.values())

--- a/src/a2a_mcp_bridge/registry/manager.py
+++ b/src/a2a_mcp_bridge/registry/manager.py
@@ -1,0 +1,77 @@
+"""Main Capability Registry manager."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from .models import AgentInfo
+from .storage import RegistryStorage
+
+logger = logging.getLogger("a2a_mcp_bridge.registry")
+
+
+class CapabilityRegistry:
+    """Central registry for Hermes agent capabilities."""
+
+    def __init__(self, db_path: str = "registry.db") -> None:
+        self.storage = RegistryStorage(db_path)
+        self._cache: Dict[str, AgentInfo] = {}
+        # Warm cache from persistent storage
+        for agent in self.storage.get_all_agents():
+            self._cache[agent.agent_id] = agent
+
+    # ── write ──────────────────────────────────────────────────────────
+
+    def announce(self, agent: AgentInfo) -> None:
+        """Register a new agent or update its capabilities."""
+        self.storage.register_agent(agent)
+        self._cache[agent.agent_id] = agent
+        logger.info(
+            "Agent %r registered with %d capabilities",
+            agent.name,
+            len(agent.capabilities),
+        )
+
+    # ── read ───────────────────────────────────────────────────────────
+
+    def query(self, keyword: str = "", max_cost: float | None = None) -> List[AgentInfo]:
+        """Query agents by keyword or cost ceiling.
+
+        For now this is a simple filter — can be enhanced with scoring later.
+        """
+        agents = list(self._cache.values())
+
+        # Filter by status
+        agents = [a for a in agents if a.status == "online"]
+
+        # Filter by keyword (match against skill_id, description, domain)
+        if keyword:
+            kw = keyword.lower()
+            agents = [
+                a
+                for a in agents
+                if any(
+                    kw in cap.skill_id.lower()
+                    or kw in cap.description.lower()
+                    or kw in cap.domain.lower()
+                    for cap in a.capabilities
+                )
+            ]
+
+        # Filter by monetary cost ceiling
+        if max_cost is not None:
+            agents = [
+                a
+                for a in agents
+                if any(
+                    cap.cost.monetary_cost_usd is not None and cap.cost.monetary_cost_usd <= max_cost
+                    for cap in a.capabilities
+                )
+            ]
+
+        return agents
+
+    def get_agent(self, agent_id: str) -> Optional[AgentInfo]:
+        """Return cached agent info (or None)."""
+        return self._cache.get(agent_id)

--- a/src/a2a_mcp_bridge/registry/manager.py
+++ b/src/a2a_mcp_bridge/registry/manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional
 
 from .models import AgentInfo
 from .storage import RegistryStorage
@@ -16,7 +15,7 @@ class CapabilityRegistry:
 
     def __init__(self, db_path: str = "registry.db") -> None:
         self.storage = RegistryStorage(db_path)
-        self._cache: Dict[str, AgentInfo] = {}
+        self._cache: dict[str, AgentInfo] = {}
         # Warm cache from persistent storage
         for agent in self.storage.get_all_agents():
             self._cache[agent.agent_id] = agent
@@ -35,7 +34,7 @@ class CapabilityRegistry:
 
     # ── read ───────────────────────────────────────────────────────────
 
-    def query(self, keyword: str = "", max_cost: float | None = None) -> List[AgentInfo]:
+    def query(self, keyword: str = "", max_cost: float | None = None) -> list[AgentInfo]:
         """Query agents by keyword or cost ceiling.
 
         For now this is a simple filter — can be enhanced with scoring later.
@@ -72,10 +71,10 @@ class CapabilityRegistry:
 
         return agents
 
-    def get_agent(self, agent_id: str) -> Optional[AgentInfo]:
+    def get_agent(self, agent_id: str) -> AgentInfo | None:
         """Return cached agent info (or None)."""
         return self._cache.get(agent_id)
 
-    def get_all_agents(self) -> List[AgentInfo]:
+    def get_all_agents(self) -> list[AgentInfo]:
         """Return all cached agents."""
         return list(self._cache.values())

--- a/src/a2a_mcp_bridge/registry/models.py
+++ b/src/a2a_mcp_bridge/registry/models.py
@@ -1,0 +1,43 @@
+"""Pydantic models for the Capability Registry (Hermes Agents)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CostModel(BaseModel):
+    """Cost and performance model for a capability."""
+
+    tokens_per_call: float = Field(..., description="Estimated tokens per typical call")
+    latency_ms: int = Field(..., description="Average latency in milliseconds")
+    monetary_cost_usd: Optional[float] = Field(None, description="Monetary cost if applicable")
+    type: Literal["local", "api", "hybrid"] = "local"
+
+
+class Capability(BaseModel):
+    """Represents one specialized skill announced by a Hermes agent."""
+
+    skill_id: str = Field(..., description="Unique skill identifier, e.g. 'code-review-python'")
+    description: str = Field(..., description="Human readable description")
+    parameters_schema: Dict[str, Any] = Field(default_factory=dict)
+    return_schema: Dict[str, Any] = Field(default_factory=dict)
+    domain: str = Field(..., description="Domain like 'code', 'research', 'media'")
+    cost: CostModel
+    supports_streaming: bool = False
+    max_context_tokens: Optional[int] = None
+    permissions: List[str] = Field(default_factory=lambda: ["read"])
+    version: str = "1.0.0"
+
+
+class AgentInfo(BaseModel):
+    """Full information about a registered Hermes agent."""
+
+    agent_id: str
+    name: str
+    capabilities: List[Capability] = Field(default_factory=list)
+    status: Literal["online", "offline", "degraded"] = "online"
+    last_heartbeat: datetime = Field(default_factory=datetime.utcnow)
+    metadata: Dict[str, Any] = Field(default_factory=dict)

--- a/src/a2a_mcp_bridge/registry/models.py
+++ b/src/a2a_mcp_bridge/registry/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -39,5 +39,5 @@ class AgentInfo(BaseModel):
     name: str
     capabilities: list[Capability] = Field(default_factory=list)
     status: Literal["online", "offline", "degraded"] = "online"
-    last_heartbeat: datetime = Field(default_factory=datetime.utcnow)
+    last_heartbeat: datetime = Field(default_factory=lambda: datetime.now(UTC))
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/a2a_mcp_bridge/registry/models.py
+++ b/src/a2a_mcp_bridge/registry/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -13,7 +13,7 @@ class CostModel(BaseModel):
 
     tokens_per_call: float = Field(..., description="Estimated tokens per typical call")
     latency_ms: int = Field(..., description="Average latency in milliseconds")
-    monetary_cost_usd: Optional[float] = Field(None, description="Monetary cost if applicable")
+    monetary_cost_usd: float | None = Field(None, description="Monetary cost if applicable")
     type: Literal["local", "api", "hybrid"] = "local"
 
 
@@ -22,13 +22,13 @@ class Capability(BaseModel):
 
     skill_id: str = Field(..., description="Unique skill identifier, e.g. 'code-review-python'")
     description: str = Field(..., description="Human readable description")
-    parameters_schema: Dict[str, Any] = Field(default_factory=dict)
-    return_schema: Dict[str, Any] = Field(default_factory=dict)
+    parameters_schema: dict[str, Any] = Field(default_factory=dict)
+    return_schema: dict[str, Any] = Field(default_factory=dict)
     domain: str = Field(..., description="Domain like 'code', 'research', 'media'")
     cost: CostModel
     supports_streaming: bool = False
-    max_context_tokens: Optional[int] = None
-    permissions: List[str] = Field(default_factory=lambda: ["read"])
+    max_context_tokens: int | None = None
+    permissions: list[str] = Field(default_factory=lambda: ["read"])
     version: str = "1.0.0"
 
 
@@ -37,7 +37,7 @@ class AgentInfo(BaseModel):
 
     agent_id: str
     name: str
-    capabilities: List[Capability] = Field(default_factory=list)
+    capabilities: list[Capability] = Field(default_factory=list)
     status: Literal["online", "offline", "degraded"] = "online"
     last_heartbeat: datetime = Field(default_factory=datetime.utcnow)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/a2a_mcp_bridge/registry/query.py
+++ b/src/a2a_mcp_bridge/registry/query.py
@@ -30,7 +30,9 @@ class RegistryQuery:
                         "domain": cap.domain,
                         "cost": cap.cost.model_dump(),
                         "supports_streaming": cap.supports_streaming,
+                        "max_context_tokens": cap.max_context_tokens,
                         "permissions": cap.permissions,
+                        "version": cap.version,
                     }
                 )
         return result
@@ -61,9 +63,11 @@ class RegistryQuery:
                     matches.append(
                         {
                             "agent_id": agent.agent_id,
+                            "agent_name": agent.name,
                             "skill_id": cap.skill_id,
                             "score": score,
                             "cost_tokens": cap.cost.tokens_per_call,
+                            "description": cap.description,
                         }
                     )
 

--- a/src/a2a_mcp_bridge/registry/query.py
+++ b/src/a2a_mcp_bridge/registry/query.py
@@ -1,0 +1,72 @@
+"""Query and discovery logic for Capability Registry."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .manager import CapabilityRegistry
+from .models import AgentInfo
+
+
+class RegistryQuery:
+    """Handles discovery and intelligent querying of capabilities."""
+
+    def __init__(self, registry: CapabilityRegistry) -> None:
+        self.registry = registry
+
+    # ── discovery ──────────────────────────────────────────────────────
+
+    def discover_all(self) -> List[Dict[str, Any]]:
+        """Return all available capabilities in a clean format for A2A/MCP."""
+        result: List[Dict[str, Any]] = []
+        for agent in self.registry.get_all_agents():
+            for cap in agent.capabilities:
+                result.append(
+                    {
+                        "agent_id": agent.agent_id,
+                        "agent_name": agent.name,
+                        "skill_id": cap.skill_id,
+                        "description": cap.description,
+                        "domain": cap.domain,
+                        "cost": cap.cost.model_dump(),
+                        "supports_streaming": cap.supports_streaming,
+                        "permissions": cap.permissions,
+                    }
+                )
+        return result
+
+    # ── scoring ────────────────────────────────────────────────────────
+
+    def find_best(
+        self,
+        skill_keyword: str,
+        max_cost: float | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Find best matching agents for a skill (simple scoring for now).
+
+        Score heuristics:
+          - base = 1.0 if keyword matches, 0.0 otherwise
+          - penalty 0.5 if max_cost is set and token cost exceeds it
+          - sorted descending by score, then ascending by token cost
+        """
+        matches: List[Dict[str, Any]] = []
+        kw = skill_keyword.lower()
+
+        for agent in self.registry.get_all_agents():
+            for cap in agent.capabilities:
+                if kw in cap.skill_id.lower() or kw in cap.description.lower():
+                    score = 1.0
+                    if max_cost is not None and cap.cost.tokens_per_call > max_cost:
+                        score = 0.5
+                    matches.append(
+                        {
+                            "agent_id": agent.agent_id,
+                            "skill_id": cap.skill_id,
+                            "score": score,
+                            "cost_tokens": cap.cost.tokens_per_call,
+                        }
+                    )
+
+        # Sort by score descending, then cost ascending
+        matches.sort(key=lambda x: (-x["score"], x["cost_tokens"]))
+        return matches

--- a/src/a2a_mcp_bridge/registry/query.py
+++ b/src/a2a_mcp_bridge/registry/query.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from .manager import CapabilityRegistry
-from .models import AgentInfo
 
 
 class RegistryQuery:
@@ -16,9 +15,9 @@ class RegistryQuery:
 
     # ── discovery ──────────────────────────────────────────────────────
 
-    def discover_all(self) -> List[Dict[str, Any]]:
+    def discover_all(self) -> list[dict[str, Any]]:
         """Return all available capabilities in a clean format for A2A/MCP."""
-        result: List[Dict[str, Any]] = []
+        result: list[dict[str, Any]] = []
         for agent in self.registry.get_all_agents():
             for cap in agent.capabilities:
                 result.append(
@@ -43,7 +42,7 @@ class RegistryQuery:
         self,
         skill_keyword: str,
         max_cost: float | None = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Find best matching agents for a skill (simple scoring for now).
 
         Score heuristics:
@@ -51,7 +50,7 @@ class RegistryQuery:
           - penalty 0.5 if max_cost is set and token cost exceeds it
           - sorted descending by score, then ascending by token cost
         """
-        matches: List[Dict[str, Any]] = []
+        matches: list[dict[str, Any]] = []
         kw = skill_keyword.lower()
 
         for agent in self.registry.get_all_agents():

--- a/src/a2a_mcp_bridge/registry/storage.py
+++ b/src/a2a_mcp_bridge/registry/storage.py
@@ -92,7 +92,7 @@ class RegistryStorage:
                 AgentInfo(
                     agent_id=agent_id,
                     name=name,
-                    status=status,  # type: ignore[arg-type]
+                    status=status,
                     last_heartbeat=datetime.fromisoformat(heartbeat_str),
                     metadata=json.loads(metadata_json) if metadata_json else {},
                     capabilities=capabilities,

--- a/src/a2a_mcp_bridge/registry/storage.py
+++ b/src/a2a_mcp_bridge/registry/storage.py
@@ -1,0 +1,111 @@
+"""SQLite persistence layer for Capability Registry."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from .models import AgentInfo, Capability
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agents (
+    agent_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    last_heartbeat TEXT NOT NULL,
+    metadata TEXT
+);
+CREATE TABLE IF NOT EXISTS capabilities (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL,
+    skill_id TEXT NOT NULL,
+    capability_json TEXT NOT NULL,
+    FOREIGN KEY (agent_id) REFERENCES agents(agent_id) ON DELETE CASCADE
+);
+"""
+
+
+class RegistryStorage:
+    """SQLite-based persistent storage for the Capability Registry."""
+
+    def __init__(self, db_path: str = "registry.db") -> None:
+        self.db_path = Path(db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(str(self.db_path))
+        conn.executescript(_SCHEMA)
+        conn.commit()
+        conn.close()
+
+    # ── write ──────────────────────────────────────────────────────────
+
+    def register_agent(self, agent: AgentInfo) -> None:
+        """Save or update agent and its capabilities."""
+        conn = sqlite3.connect(str(self.db_path))
+
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO agents
+            (agent_id, name, status, last_heartbeat, metadata)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                agent.agent_id,
+                agent.name,
+                agent.status,
+                agent.last_heartbeat.isoformat(),
+                json.dumps(agent.metadata),
+            ),
+        )
+
+        # Replace capabilities for this agent
+        conn.execute("DELETE FROM capabilities WHERE agent_id = ?", (agent.agent_id,))
+        for cap in agent.capabilities:
+            conn.execute(
+                "INSERT INTO capabilities (agent_id, skill_id, capability_json) VALUES (?, ?, ?)",
+                (agent.agent_id, cap.skill_id, cap.model_dump_json()),
+            )
+
+        conn.commit()
+        conn.close()
+
+    # ── read ───────────────────────────────────────────────────────────
+
+    def get_all_agents(self) -> List[AgentInfo]:
+        """Load all agents with their capabilities."""
+        conn = sqlite3.connect(str(self.db_path))
+        agents: List[AgentInfo] = []
+
+        for row in conn.execute("SELECT * FROM agents"):
+            agent_id, name, status, heartbeat_str, metadata_json = row
+            capabilities: List[Capability] = []
+            for cap_row in conn.execute(
+                "SELECT capability_json FROM capabilities WHERE agent_id = ?",
+                (agent_id,),
+            ):
+                capabilities.append(Capability.model_validate_json(cap_row[0]))
+
+            agents.append(
+                AgentInfo(
+                    agent_id=agent_id,
+                    name=name,
+                    status=status,  # type: ignore[arg-type]
+                    last_heartbeat=datetime.fromisoformat(heartbeat_str),
+                    metadata=json.loads(metadata_json) if metadata_json else {},
+                    capabilities=capabilities,
+                )
+            )
+
+        conn.close()
+        return agents
+
+    def get_agent(self, agent_id: str) -> Optional[AgentInfo]:
+        """Load a single agent by ID (or None if not found)."""
+        for agent in self.get_all_agents():
+            if agent.agent_id == agent_id:
+                return agent
+        return None

--- a/src/a2a_mcp_bridge/registry/storage.py
+++ b/src/a2a_mcp_bridge/registry/storage.py
@@ -6,7 +6,6 @@ import json
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
 
 from .models import AgentInfo, Capability
 
@@ -75,14 +74,14 @@ class RegistryStorage:
 
     # ── read ───────────────────────────────────────────────────────────
 
-    def get_all_agents(self) -> List[AgentInfo]:
+    def get_all_agents(self) -> list[AgentInfo]:
         """Load all agents with their capabilities."""
         conn = sqlite3.connect(str(self.db_path))
-        agents: List[AgentInfo] = []
+        agents: list[AgentInfo] = []
 
         for row in conn.execute("SELECT * FROM agents"):
             agent_id, name, status, heartbeat_str, metadata_json = row
-            capabilities: List[Capability] = []
+            capabilities: list[Capability] = []
             for cap_row in conn.execute(
                 "SELECT capability_json FROM capabilities WHERE agent_id = ?",
                 (agent_id,),
@@ -103,7 +102,7 @@ class RegistryStorage:
         conn.close()
         return agents
 
-    def get_agent(self, agent_id: str) -> Optional[AgentInfo]:
+    def get_agent(self, agent_id: str) -> AgentInfo | None:
         """Load a single agent by ID (or None if not found)."""
         for agent in self.get_all_agents():
             if agent.agent_id == agent_id:

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -17,6 +17,10 @@ from mcp.server.lowlevel import NotificationOptions
 from mcp.server.stdio import stdio_server
 
 from .bus_store import BusStore
+from .registry.heartbeat import HeartbeatManager
+from .registry.manager import CapabilityRegistry
+from .registry.models import AgentInfo
+from .registry.query import RegistryQuery
 from .signals import SignalDir
 from .store import Store
 from .tools import (
@@ -29,10 +33,6 @@ from .tools import (
     tool_agent_send_file,
     tool_agent_subscribe,
 )
-from .registry.heartbeat import HeartbeatManager
-from .registry.manager import CapabilityRegistry
-from .registry.models import AgentInfo
-from .registry.query import RegistryQuery
 from .validation import validate_tool_params
 from .wake import WebhookWaker, load_registry
 
@@ -273,7 +273,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     store.upsert_agent(agent_id)
 
     # Capability Registry — SQLite-backed, co-located with main DB
-    registry_db_path = str(Path(db_path).with_name("registry.db"))
+    registry_db_path = str(Path(db_path).with_suffix(".registry.db"))
     cap_registry = CapabilityRegistry(registry_db_path)
     cap_query = RegistryQuery(cap_registry)
     heartbeat_interval = int(os.environ.get("A2A_HEARTBEAT_INTERVAL", "30"))

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -586,10 +586,15 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         Args:
             payload: JSON string matching the AgentInfo schema.
         """
+        from pydantic import ValidationError
+
+        from .exceptions import MCPValidationError
+
+        validate_tool_params(tool="capability_announce", params={"payload": payload})
         try:
             agent = AgentInfo.model_validate_json(payload)
-        except Exception as exc:
-            return {"status": "error", "message": str(exc)}
+        except ValidationError as exc:
+            raise MCPValidationError(f"invalid capability payload: {exc}") from exc
         cap_registry.announce(agent)
         return {"status": "ok", "registered": len(agent.capabilities)}
 
@@ -618,7 +623,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     @mcp.tool()
     def capability_discover() -> dict[str, Any]:
         """List all available capabilities across all registered agents."""
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         capabilities = cap_query.discover_all()
         return {
@@ -626,7 +631,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             "type": "capability_discovery",
             "capabilities": capabilities,
             "total_agents": len({c["agent_id"] for c in capabilities}),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
         }
 
     @mcp.tool()

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -29,6 +29,8 @@ from .tools import (
     tool_agent_send_file,
     tool_agent_subscribe,
 )
+from .registry.manager import CapabilityRegistry
+from .registry.models import AgentInfo
 from .validation import validate_tool_params
 from .wake import WebhookWaker, load_registry
 
@@ -248,6 +250,10 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         # below call _load_waker_if_stale() directly to pick up hot reloads.
         _load_waker_if_stale()
     store.upsert_agent(agent_id)
+
+    # Capability Registry — SQLite-backed, co-located with main DB
+    registry_db_path = str(Path(db_path).with_name("registry.db"))
+    cap_registry = CapabilityRegistry(registry_db_path)
 
     mcp = A2AMcp("a2a-mcp-bridge")
 
@@ -546,6 +552,41 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             params={"transfer_id": transfer_id},
         )
         return tool_agent_delete_file(store, agent_id, transfer_id)
+
+    # ── Capability Registry tools ──────────────────────────────────────
+
+    @mcp.tool()
+    def capability_announce(payload: str) -> dict[str, Any]:
+        """Register or update an agent's capabilities in the registry.
+
+        Args:
+            payload: JSON string matching the AgentInfo schema.
+        """
+        agent = AgentInfo.model_validate_json(payload)
+        cap_registry.announce(agent)
+        return {"status": "ok", "registered": len(agent.capabilities)}
+
+    @mcp.tool()
+    def capability_query(keyword: str = "", max_cost: float | None = None) -> dict[str, Any]:
+        """Query agents by keyword and/or cost ceiling.
+
+        Args:
+            keyword: Match against skill_id, description, or domain.
+            max_cost: Maximum monetary cost (USD) per call filter.
+        """
+        agents = cap_registry.query(keyword=keyword, max_cost=max_cost)
+        return {
+            "agents": [
+                {
+                    "agent_id": a.agent_id,
+                    "name": a.name,
+                    "status": a.status,
+                    "capabilities": [c.skill_id for c in a.capabilities],
+                }
+                for a in agents
+            ],
+            "count": len(agents),
+        }
 
     return mcp
 

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -593,12 +593,15 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     @mcp.tool()
     def capability_discover() -> dict[str, Any]:
         """List all available capabilities across all registered agents."""
+        from datetime import datetime
+
         capabilities = cap_query.discover_all()
         return {
             "status": "success",
             "type": "capability_discovery",
             "capabilities": capabilities,
             "total_agents": len({c["agent_id"] for c in capabilities}),
+            "timestamp": datetime.utcnow().isoformat(),
         }
 
     @mcp.tool()

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -276,7 +276,8 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     registry_db_path = str(Path(db_path).with_name("registry.db"))
     cap_registry = CapabilityRegistry(registry_db_path)
     cap_query = RegistryQuery(cap_registry)
-    heartbeat = HeartbeatManager(cap_registry, interval_seconds=30)
+    heartbeat_interval = int(os.environ.get("A2A_HEARTBEAT_INTERVAL", "30"))
+    heartbeat = HeartbeatManager(cap_registry, interval_seconds=heartbeat_interval)
 
     mcp = A2AMcp("a2a-mcp-bridge")
 

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -29,6 +29,7 @@ from .tools import (
     tool_agent_send_file,
     tool_agent_subscribe,
 )
+from .registry.heartbeat import HeartbeatManager
 from .registry.manager import CapabilityRegistry
 from .registry.models import AgentInfo
 from .registry.query import RegistryQuery
@@ -222,16 +223,35 @@ class A2AMcp(FastMCP):
         which this override can be deleted.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._on_startup: list[Any] = []
+        self._on_shutdown: list[Any] = []
+
+    def on_startup(self, fn: Any) -> None:
+        """Register an async callable to run when the server starts."""
+        self._on_startup.append(fn)
+
+    def on_shutdown(self, fn: Any) -> None:
+        """Register an async callable to run when the server stops."""
+        self._on_shutdown.append(fn)
+
     async def run_stdio_async(self) -> None:
         # Kept in sync with FastMCP.run_stdio_async (mcp>=1.0,<2). See class docstring.
-        async with stdio_server() as (read_stream, write_stream):
-            await self._mcp_server.run(
-                read_stream,
-                write_stream,
-                self._mcp_server.create_initialization_options(
-                    notification_options=NotificationOptions(tools_changed=True),
-                ),
-            )
+        for fn in self._on_startup:
+            await fn()
+        try:
+            async with stdio_server() as (read_stream, write_stream):
+                await self._mcp_server.run(
+                    read_stream,
+                    write_stream,
+                    self._mcp_server.create_initialization_options(
+                        notification_options=NotificationOptions(tools_changed=True),
+                    ),
+                )
+        finally:
+            for fn in self._on_shutdown:
+                await fn()
 
 
 def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None, bus_url: str | None = None, bus_api_key: str | None = None) -> FastMCP:
@@ -256,6 +276,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     registry_db_path = str(Path(db_path).with_name("registry.db"))
     cap_registry = CapabilityRegistry(registry_db_path)
     cap_query = RegistryQuery(cap_registry)
+    heartbeat = HeartbeatManager(cap_registry, interval_seconds=30)
 
     mcp = A2AMcp("a2a-mcp-bridge")
 
@@ -619,6 +640,21 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
             "results": results,
             "count": len(results),
         }
+
+    @mcp.tool()
+    def capability_ping(agent_id: str) -> dict[str, Any]:
+        """Signal that an agent is still alive (heartbeat ping).
+
+        Args:
+            agent_id: The agent sending the heartbeat.
+        """
+        heartbeat.ping(agent_id)
+        return {"status": "ok", "agent_id": agent_id}
+
+    # ── Lifecycle hooks ────────────────────────────────────────────────
+
+    mcp.on_startup(heartbeat.start)
+    mcp.on_shutdown(heartbeat.stop)
 
     return mcp
 

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -31,6 +31,7 @@ from .tools import (
 )
 from .registry.manager import CapabilityRegistry
 from .registry.models import AgentInfo
+from .registry.query import RegistryQuery
 from .validation import validate_tool_params
 from .wake import WebhookWaker, load_registry
 
@@ -254,6 +255,7 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
     # Capability Registry — SQLite-backed, co-located with main DB
     registry_db_path = str(Path(db_path).with_name("registry.db"))
     cap_registry = CapabilityRegistry(registry_db_path)
+    cap_query = RegistryQuery(cap_registry)
 
     mcp = A2AMcp("a2a-mcp-bridge")
 
@@ -586,6 +588,33 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
                 for a in agents
             ],
             "count": len(agents),
+        }
+
+    @mcp.tool()
+    def capability_discover() -> dict[str, Any]:
+        """List all available capabilities across all registered agents."""
+        capabilities = cap_query.discover_all()
+        return {
+            "status": "success",
+            "type": "capability_discovery",
+            "capabilities": capabilities,
+            "total_agents": len({c["agent_id"] for c in capabilities}),
+        }
+
+    @mcp.tool()
+    def capability_find_best(skill: str, max_cost: float | None = None) -> dict[str, Any]:
+        """Find the best matching agents for a specific skill keyword.
+
+        Args:
+            skill: Keyword to match against skill_id or description.
+            max_cost: Optional token-cost ceiling for scoring.
+        """
+        results = cap_query.find_best(skill, max_cost=max_cost)
+        return {
+            "status": "success",
+            "query": skill,
+            "results": results,
+            "count": len(results),
         }
 
     return mcp

--- a/src/a2a_mcp_bridge/server.py
+++ b/src/a2a_mcp_bridge/server.py
@@ -585,7 +585,10 @@ def build_server(agent_id: str, db_path: str, signal_dir_path: str | None = None
         Args:
             payload: JSON string matching the AgentInfo schema.
         """
-        agent = AgentInfo.model_validate_json(payload)
+        try:
+            agent = AgentInfo.model_validate_json(payload)
+        except Exception as exc:
+            return {"status": "error", "message": str(exc)}
         cap_registry.announce(agent)
         return {"status": "ok", "registered": len(agent.capabilities)}
 

--- a/src/a2a_mcp_bridge/validation.py
+++ b/src/a2a_mcp_bridge/validation.py
@@ -110,6 +110,8 @@ def validate_tool_params(
         _validate_agent_fetch_file(params)
     elif tool == "agent_delete_file":
         _validate_agent_delete_file(params)
+    elif tool == "capability_announce":
+        _validate_capability_announce(params)
 
     return params
 
@@ -199,3 +201,12 @@ def _validate_agent_delete_file(params: dict[str, Any]) -> None:
     transfer_id = params.get("transfer_id")
     if not isinstance(transfer_id, str) or not transfer_id:
         raise MCPValidationError("'transfer_id' must be a non-empty string")
+
+
+def _validate_capability_announce(params: dict[str, Any]) -> None:
+    """Validate capability_announce parameters (payload must be non-empty string)."""
+    from .exceptions import MCPValidationError
+
+    payload = params.get("payload")
+    if not isinstance(payload, str) or not payload:
+        raise MCPValidationError("'payload' must be a non-empty JSON string")

--- a/tests/test_registry/test_heartbeat.py
+++ b/tests/test_registry/test_heartbeat.py
@@ -1,0 +1,117 @@
+"""Unit tests for HeartbeatManager — ping, stale cleanup, lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from a2a_mcp_bridge.registry.heartbeat import HeartbeatManager
+from a2a_mcp_bridge.registry.manager import CapabilityRegistry
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> CapabilityRegistry:
+    db_path = tmp_path / "registry.db"
+    return CapabilityRegistry(str(db_path))
+
+
+@pytest.fixture
+def heartbeat(registry: CapabilityRegistry) -> HeartbeatManager:
+    return HeartbeatManager(registry, interval_seconds=5)
+
+
+def _make_agent(agent_id: str = "hb-agent") -> AgentInfo:
+    return AgentInfo(
+        agent_id=agent_id,
+        name="HB Agent",
+        capabilities=[
+            Capability(
+                skill_id="test-skill",
+                description="test",
+                domain="test",
+                cost=CostModel(tokens_per_call=10, latency_ms=50),
+            )
+        ],
+    )
+
+
+def test_ping_records_timestamp(heartbeat: HeartbeatManager):
+    heartbeat.ping("agent-1")
+    assert "agent-1" in heartbeat._last_heartbeat
+    assert heartbeat._last_heartbeat["agent-1"] > 0
+
+
+def test_cleanup_stale_marks_offline(registry: CapabilityRegistry, heartbeat: HeartbeatManager):
+    agent = _make_agent()
+    registry.announce(agent)
+
+    # Simulate a stale ping (long ago)
+    import time
+    heartbeat._last_heartbeat["hb-agent"] = time.time() - (heartbeat.interval * 3)
+
+    heartbeat._cleanup_stale_agents()
+
+    updated = registry.get_agent("hb-agent")
+    assert updated is not None
+    assert updated.status == "offline"
+
+
+def test_cleanup_stale_leaves_fresh_alone(registry: CapabilityRegistry, heartbeat: HeartbeatManager):
+    agent = _make_agent()
+    registry.announce(agent)
+
+    # Fresh ping
+    heartbeat.ping("hb-agent")
+
+    heartbeat._cleanup_stale_agents()
+
+    updated = registry.get_agent("hb-agent")
+    assert updated is not None
+    assert updated.status == "online"
+
+
+def test_cleanup_stale_skips_already_offline(registry: CapabilityRegistry, heartbeat: HeartbeatManager):
+    agent = _make_agent()
+    agent.status = "offline"
+    registry.announce(agent)
+
+    import time
+    heartbeat._last_heartbeat["hb-agent"] = time.time() - 999
+
+    # Should not crash or double-process
+    heartbeat._cleanup_stale_agents()
+
+    updated = registry.get_agent("hb-agent")
+    assert updated is not None
+    assert updated.status == "offline"
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop(heartbeat: HeartbeatManager):
+    await heartbeat.start()
+    assert heartbeat._running is True
+    assert heartbeat._task is not None
+
+    await heartbeat.stop()
+    assert heartbeat._running is False
+    assert heartbeat._task is None
+
+
+@pytest.mark.asyncio
+async def test_start_idempotent(heartbeat: HeartbeatManager):
+    await heartbeat.start()
+    await heartbeat.start()  # should not create a second task
+    assert heartbeat._running is True
+
+    await heartbeat.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started(heartbeat: HeartbeatManager):
+    # Should not raise
+    await heartbeat.stop()
+    assert heartbeat._running is False

--- a/tests/test_registry/test_heartbeat.py
+++ b/tests/test_registry/test_heartbeat.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_registry/test_manager.py
+++ b/tests/test_registry/test_manager.py
@@ -118,3 +118,58 @@ def test_query_filters_offline(registry: CapabilityRegistry):
 
 def test_get_agent_missing(registry: CapabilityRegistry):
     assert registry.get_agent("nonexistent") is None
+
+
+def test_concurrent_announce_and_query_no_race(registry: CapabilityRegistry):
+    """Regression guard: announce() and query() must be safe under concurrency.
+
+    Before the RLock on _cache, ``HeartbeatManager._cleanup_stale_agents``
+    mutating the cache from a background task while an MCP tool was
+    iterating ``self._cache.values()`` could raise
+    ``RuntimeError: dictionary changed size during iteration``.
+
+    This test exercises that pattern directly by hammering announce() and
+    query()/get_all_agents() from multiple threads for a short burst.
+    Any concurrent-mutation bug will raise; a clean run proves the lock
+    serialises access correctly.
+    """
+    import threading as _threading
+
+    errors: list[BaseException] = []
+    stop = _threading.Event()
+
+    def writer() -> None:
+        i = 0
+        while not stop.is_set():
+            try:
+                registry.announce(_make_agent(f"a{i % 50}", f"Agent {i}"))
+                i += 1
+            except BaseException as exc:
+                errors.append(exc)
+                return
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                registry.query(keyword="python")
+                registry.get_all_agents()
+            except BaseException as exc:
+                errors.append(exc)
+                return
+
+    threads = [
+        _threading.Thread(target=writer),
+        _threading.Thread(target=writer),
+        _threading.Thread(target=reader),
+        _threading.Thread(target=reader),
+    ]
+    for t in threads:
+        t.start()
+
+    # Hammer for 200 ms — enough to expose a missing lock.
+    stop.wait(0.2)
+    stop.set()
+    for t in threads:
+        t.join(timeout=2.0)
+
+    assert errors == [], f"concurrent access raised: {errors!r}"

--- a/tests/test_registry/test_manager.py
+++ b/tests/test_registry/test_manager.py
@@ -1,0 +1,120 @@
+"""Unit tests for CapabilityRegistry manager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.registry.manager import CapabilityRegistry
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> CapabilityRegistry:
+    db_path = tmp_path / "registry.db"
+    return CapabilityRegistry(str(db_path))
+
+
+def _make_agent(agent_id: str = "test-agent", name: str = "Test Agent") -> AgentInfo:
+    return AgentInfo(
+        agent_id=agent_id,
+        name=name,
+        capabilities=[
+            Capability(
+                skill_id="code-review-python",
+                description="Performs Python code reviews",
+                domain="code",
+                cost=CostModel(tokens_per_call=200, latency_ms=800),
+            ),
+            Capability(
+                skill_id="diagram-generation",
+                description="Generates architecture diagrams",
+                domain="creative",
+                cost=CostModel(tokens_per_call=80, latency_ms=400, monetary_cost_usd=0.002),
+            ),
+        ],
+    )
+
+
+def test_announce_and_get(registry: CapabilityRegistry):
+    agent = _make_agent()
+    registry.announce(agent)
+
+    found = registry.get_agent("test-agent")
+    assert found is not None
+    assert found.name == "Test Agent"
+    assert len(found.capabilities) == 2
+
+
+def test_announce_updates_existing(registry: CapabilityRegistry):
+    v1 = _make_agent(name="v1")
+    registry.announce(v1)
+
+    v2 = _make_agent(name="v2")
+    v2.capabilities = [
+        Capability(
+            skill_id="new-skill",
+            description="Brand new",
+            domain="test",
+            cost=CostModel(tokens_per_call=10, latency_ms=50),
+        )
+    ]
+    registry.announce(v2)
+
+    found = registry.get_agent("test-agent")
+    assert found is not None
+    assert found.name == "v2"
+    assert len(found.capabilities) == 1
+    assert found.capabilities[0].skill_id == "new-skill"
+
+
+def test_get_all_agents(registry: CapabilityRegistry):
+    registry.announce(_make_agent("a1", "Agent 1"))
+    registry.announce(_make_agent("a2", "Agent 2"))
+
+    all_agents = registry.get_all_agents()
+    assert len(all_agents) == 2
+    names = {a.name for a in all_agents}
+    assert names == {"Agent 1", "Agent 2"}
+
+
+def test_query_by_keyword(registry: CapabilityRegistry):
+    registry.announce(_make_agent())
+
+    # Match skill_id
+    results = registry.query(keyword="python")
+    assert len(results) == 1
+
+    # Match domain
+    results = registry.query(keyword="creative")
+    assert len(results) == 1
+
+    # No match
+    results = registry.query(keyword="rust")
+    assert len(results) == 0
+
+
+def test_query_by_max_cost(registry: CapabilityRegistry):
+    registry.announce(_make_agent())
+
+    # Agent has a capability with monetary_cost_usd=0.002
+    results = registry.query(max_cost=0.005)
+    assert len(results) == 1
+
+    # Too low — no match
+    results = registry.query(max_cost=0.001)
+    assert len(results) == 0
+
+
+def test_query_filters_offline(registry: CapabilityRegistry):
+    agent = _make_agent()
+    agent.status = "offline"
+    registry.announce(agent)
+
+    results = registry.query()
+    assert len(results) == 0
+
+
+def test_get_agent_missing(registry: CapabilityRegistry):
+    assert registry.get_agent("nonexistent") is None

--- a/tests/test_registry/test_models.py
+++ b/tests/test_registry/test_models.py
@@ -1,0 +1,48 @@
+"""Unit tests for Capability Registry models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+
+
+def test_cost_model():
+    cost = CostModel(tokens_per_call=150.0, latency_ms=450, type="local")
+    assert cost.tokens_per_call == 150.0
+    assert cost.type == "local"
+    assert cost.monetary_cost_usd is None
+
+
+def test_capability():
+    cap = Capability(
+        skill_id="code-review-python",
+        description="Performs Python code reviews",
+        domain="code",
+        cost=CostModel(tokens_per_call=200, latency_ms=800),
+    )
+    assert cap.skill_id == "code-review-python"
+    assert cap.supports_streaming is False
+    assert cap.permissions == ["read"]
+    assert cap.version == "1.0.0"
+
+
+def test_agent_info():
+    agent = AgentInfo(
+        agent_id="hermes-code-01",
+        name="Python Specialist",
+        capabilities=[
+            Capability(
+                skill_id="code-review",
+                description="...",
+                domain="code",
+                cost=CostModel(tokens_per_call=100, latency_ms=300),
+            )
+        ],
+    )
+    assert agent.name == "Python Specialist"
+    assert len(agent.capabilities) == 1
+    assert agent.status == "online"
+    assert isinstance(agent.last_heartbeat, datetime)

--- a/tests/test_registry/test_models.py
+++ b/tests/test_registry/test_models.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import pytest
-
 from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
 
 

--- a/tests/test_registry/test_query.py
+++ b/tests/test_registry/test_query.py
@@ -1,0 +1,139 @@
+"""Unit tests for RegistryQuery — discover_all + find_best."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.registry.manager import CapabilityRegistry
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+from a2a_mcp_bridge.registry.query import RegistryQuery
+
+
+@pytest.fixture
+def query(tmp_path: Path) -> RegistryQuery:
+    db_path = tmp_path / "registry.db"
+    registry = CapabilityRegistry(str(db_path))
+    return RegistryQuery(registry)
+
+
+def _make_agent(
+    agent_id: str = "agent-1",
+    name: str = "Agent One",
+    skills: list[tuple[str, str, float]] | None = None,
+) -> AgentInfo:
+    if skills is None:
+        skills = [
+            ("code-review-python", "Python code reviews", 200),
+            ("arxiv-search", "Search arXiv papers", 500),
+        ]
+    return AgentInfo(
+        agent_id=agent_id,
+        name=name,
+        capabilities=[
+            Capability(
+                skill_id=sid,
+                description=desc,
+                domain="code" if "code" in sid else "research",
+                cost=CostModel(tokens_per_call=tokens, latency_ms=800, monetary_cost_usd=tokens * 0.00001),
+            )
+            for sid, desc, tokens in skills
+        ],
+    )
+
+
+def test_discover_all_empty(query: RegistryQuery):
+    result = query.discover_all()
+    assert result == []
+
+
+def test_discover_all(query: RegistryQuery):
+    query.registry.announce(_make_agent())
+
+    result = query.discover_all()
+    assert len(result) == 2
+
+    # Check structure
+    entry = result[0]
+    assert "agent_id" in entry
+    assert "agent_name" in entry
+    assert "skill_id" in entry
+    assert "description" in entry
+    assert "domain" in entry
+    assert "cost" in entry
+    assert "max_context_tokens" in entry
+    assert "version" in entry
+    assert "supports_streaming" in entry
+    assert "permissions" in entry
+
+
+def test_discover_all_multiple_agents(query: RegistryQuery):
+    query.registry.announce(_make_agent("a1", "Agent 1"))
+    query.registry.announce(_make_agent("a2", "Agent 2"))
+
+    result = query.discover_all()
+    assert len(result) == 4  # 2 capabilities × 2 agents
+
+
+def test_find_best_matching(query: RegistryQuery):
+    query.registry.announce(_make_agent())
+
+    results = query.find_best("python")
+    assert len(results) == 1
+    assert results[0]["skill_id"] == "code-review-python"
+    assert results[0]["score"] == 1.0
+
+
+def test_find_best_no_match(query: RegistryQuery):
+    query.registry.announce(_make_agent())
+
+    results = query.find_best("rust")
+    assert len(results) == 0
+
+
+def test_find_best_cost_penalty(query: RegistryQuery):
+    # Agent with expensive skill
+    agent = _make_agent(skills=[("expensive-skill", "Very expensive", 5000)])
+    query.registry.announce(agent)
+
+    # Within budget → score 1.0
+    results = query.find_best("expensive", max_cost=10000)
+    assert len(results) == 1
+    assert results[0]["score"] == 1.0
+
+    # Over budget → score 0.5
+    results = query.find_best("expensive", max_cost=100)
+    assert len(results) == 1
+    assert results[0]["score"] == 0.5
+
+
+def test_find_best_sorted_by_score_then_cost(query: RegistryQuery):
+    # Two agents with same skill keyword but different costs
+    cheap = _make_agent(
+        "cheap-agent",
+        "Cheap",
+        [("code-review", "Code review cheap", 100)],
+    )
+    expensive = _make_agent(
+        "expensive-agent",
+        "Expensive",
+        [("code-review", "Code review expensive", 500)],
+    )
+    query.registry.announce(cheap)
+    query.registry.announce(expensive)
+
+    results = query.find_best("code-review")
+    assert len(results) == 2
+    # Both score 1.0, but cheap first (lower cost)
+    assert results[0]["agent_id"] == "cheap-agent"
+    assert results[1]["agent_id"] == "expensive-agent"
+
+
+def test_find_best_includes_agent_name(query: RegistryQuery):
+    query.registry.announce(_make_agent())
+
+    results = query.find_best("python")
+    assert len(results) == 1
+    assert results[0]["agent_name"] == "Agent One"
+    assert results[0]["description"] == "Python code reviews"

--- a/tests/test_registry/test_query.py
+++ b/tests/test_registry/test_query.py
@@ -73,7 +73,7 @@ def test_discover_all_multiple_agents(query: RegistryQuery):
     query.registry.announce(_make_agent("a2", "Agent 2"))
 
     result = query.discover_all()
-    assert len(result) == 4  # 2 capabilities × 2 agents
+    assert len(result) == 4  # 2 capabilities x 2 agents
 
 
 def test_find_best_matching(query: RegistryQuery):

--- a/tests/test_registry/test_storage.py
+++ b/tests/test_registry/test_storage.py
@@ -1,0 +1,99 @@
+"""Unit tests for RegistryStorage with SQLite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.registry.models import AgentInfo, Capability, CostModel
+from a2a_mcp_bridge.registry.storage import RegistryStorage
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> RegistryStorage:
+    """Fresh RegistryStorage backed by a temp SQLite file."""
+    db_path = tmp_path / "registry.db"
+    return RegistryStorage(str(db_path))
+
+
+def test_register_and_get_all(storage: RegistryStorage):
+    agent = AgentInfo(
+        agent_id="test-agent-1",
+        name="Test Agent",
+        capabilities=[
+            Capability(
+                skill_id="test-skill",
+                description="A test skill",
+                domain="test",
+                cost=CostModel(tokens_per_call=50, latency_ms=100),
+            )
+        ],
+    )
+
+    storage.register_agent(agent)
+    agents = storage.get_all_agents()
+
+    assert len(agents) == 1
+    assert agents[0].name == "Test Agent"
+    assert agents[0].capabilities[0].skill_id == "test-skill"
+
+
+def test_register_updates_existing(storage: RegistryStorage):
+    """Registering the same agent_id replaces capabilities."""
+    agent_v1 = AgentInfo(
+        agent_id="dup-agent",
+        name="Dup Agent v1",
+        capabilities=[
+            Capability(
+                skill_id="skill-a",
+                description="A",
+                domain="test",
+                cost=CostModel(tokens_per_call=10, latency_ms=50),
+            )
+        ],
+    )
+    agent_v2 = AgentInfo(
+        agent_id="dup-agent",
+        name="Dup Agent v2",
+        capabilities=[
+            Capability(
+                skill_id="skill-b",
+                description="B",
+                domain="test",
+                cost=CostModel(tokens_per_call=20, latency_ms=100),
+            ),
+            Capability(
+                skill_id="skill-c",
+                description="C",
+                domain="test",
+                cost=CostModel(tokens_per_call=30, latency_ms=150),
+            ),
+        ],
+    )
+
+    storage.register_agent(agent_v1)
+    storage.register_agent(agent_v2)
+
+    agents = storage.get_all_agents()
+    assert len(agents) == 1
+    assert agents[0].name == "Dup Agent v2"
+    assert len(agents[0].capabilities) == 2
+    skill_ids = {c.skill_id for c in agents[0].capabilities}
+    assert skill_ids == {"skill-b", "skill-c"}
+
+
+def test_get_agent_by_id(storage: RegistryStorage):
+    agent = AgentInfo(
+        agent_id="lookup-agent",
+        name="Lookup Agent",
+        capabilities=[],
+    )
+    storage.register_agent(agent)
+
+    found = storage.get_agent("lookup-agent")
+    assert found is not None
+    assert found.name == "Lookup Agent"
+
+    missing = storage.get_agent("nonexistent")
+    assert missing is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,3 +248,124 @@ def test_agent_send_file_wrapper_rejects_missing_file_path(tmp_path: Path) -> No
 
     with pytest.raises(MCPValidationError, match="file_path"):
         agent_send_file(target="bob", file_path="")
+
+
+# ---------------------------------------------------------------------------
+# Capability Registry wrapper tests (v0.8 — pattern 0.7.7)
+#
+# Regression guard: 28 registry unit tests exercise CapabilityRegistry,
+# RegistryQuery and HeartbeatManager in isolation. Nothing previously
+# asserted that build_server() actually wires the 5 capability_* MCP tools
+# into those components. A refactor that dropped cap_registry.announce(agent)
+# or removed an @mcp.tool() wrapper would leave every unit test green while
+# silently disabling capability registration.
+# ---------------------------------------------------------------------------
+
+
+def _valid_agent_payload(agent_id: str = "alice", skill: str = "code-review") -> str:
+    """Return a minimal valid AgentInfo JSON payload for announce tests."""
+    import json as _json
+
+    return _json.dumps(
+        {
+            "agent_id": agent_id,
+            "name": f"Agent {agent_id}",
+            "status": "online",
+            "capabilities": [
+                {
+                    "skill_id": skill,
+                    "description": f"{skill} capability",
+                    "domain": "software",
+                    "cost": {
+                        "tokens_per_call": 1000,
+                        "latency_ms": 500,
+                        "monetary_cost_usd": 0.01,
+                        "type": "local",
+                    },
+                }
+            ],
+            "metadata": {},
+        }
+    )
+
+
+def test_capability_announce_wrapper_registers_agent(tmp_path: Path) -> None:
+    """build_server().capability_announce must persist the agent via cap_registry."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    capability_announce = _get_tool_fn(mcp, "capability_announce")
+
+    result = capability_announce(payload=_valid_agent_payload("alice", "python"))
+
+    assert result == {"status": "ok", "registered": 1}
+
+
+def test_capability_announce_wrapper_rejects_bad_payload(tmp_path: Path) -> None:
+    """capability_announce must return a structured error for invalid JSON."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    capability_announce = _get_tool_fn(mcp, "capability_announce")
+
+    result = capability_announce(payload="not-valid-json")
+
+    assert result["status"] == "error"
+    assert "message" in result
+
+
+def test_capability_query_wrapper_returns_matching_agents(tmp_path: Path) -> None:
+    """capability_query must filter registered agents by keyword."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    announce = _get_tool_fn(mcp, "capability_announce")
+    query = _get_tool_fn(mcp, "capability_query")
+
+    announce(payload=_valid_agent_payload("alice", "python-review"))
+    announce(payload=_valid_agent_payload("bob", "rust-review"))
+
+    result = query(keyword="python")
+
+    assert result["count"] == 1
+    assert result["agents"][0]["agent_id"] == "alice"
+
+
+def test_capability_discover_wrapper_lists_all_capabilities(tmp_path: Path) -> None:
+    """capability_discover must return all capabilities across registered agents."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    announce = _get_tool_fn(mcp, "capability_announce")
+    discover = _get_tool_fn(mcp, "capability_discover")
+
+    announce(payload=_valid_agent_payload("alice", "skill-a"))
+    announce(payload=_valid_agent_payload("bob", "skill-b"))
+
+    result = discover()
+
+    assert result["status"] == "success"
+    assert result["total_agents"] == 2
+    assert len(result["capabilities"]) == 2
+
+
+def test_capability_find_best_wrapper_returns_matches(tmp_path: Path) -> None:
+    """capability_find_best must return scored matches for the skill keyword."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    announce = _get_tool_fn(mcp, "capability_announce")
+    find_best = _get_tool_fn(mcp, "capability_find_best")
+
+    announce(payload=_valid_agent_payload("alice", "code-review-python"))
+
+    result = find_best(skill="python")
+
+    assert result["status"] == "success"
+    assert result["count"] == 1
+
+
+def test_capability_ping_wrapper_records_heartbeat(tmp_path: Path) -> None:
+    """capability_ping must delegate to HeartbeatManager.ping."""
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    ping = _get_tool_fn(mcp, "capability_ping")
+
+    result = ping(agent_id="alice")
+
+    assert result == {"status": "ok", "agent_id": "alice"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -301,15 +301,27 @@ def test_capability_announce_wrapper_registers_agent(tmp_path: Path) -> None:
 
 
 def test_capability_announce_wrapper_rejects_bad_payload(tmp_path: Path) -> None:
-    """capability_announce must return a structured error for invalid JSON."""
+    """capability_announce must raise MCPValidationError for invalid JSON."""
+    from a2a_mcp_bridge.exceptions import MCPValidationError
+
     db = tmp_path / "bus.sqlite"
     mcp = server_module.build_server(agent_id="alice", db_path=str(db))
     capability_announce = _get_tool_fn(mcp, "capability_announce")
 
-    result = capability_announce(payload="not-valid-json")
+    with pytest.raises(MCPValidationError, match="invalid capability payload"):
+        capability_announce(payload="not-valid-json")
 
-    assert result["status"] == "error"
-    assert "message" in result
+
+def test_capability_announce_wrapper_rejects_empty_payload(tmp_path: Path) -> None:
+    """capability_announce must call validate_tool_params (empty string rejected)."""
+    from a2a_mcp_bridge.exceptions import MCPValidationError
+
+    db = tmp_path / "bus.sqlite"
+    mcp = server_module.build_server(agent_id="alice", db_path=str(db))
+    capability_announce = _get_tool_fn(mcp, "capability_announce")
+
+    with pytest.raises(MCPValidationError, match="payload"):
+        capability_announce(payload="")
 
 
 def test_capability_query_wrapper_returns_matching_agents(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Finalise the `capability-registry` feature branch by addressing the blocker items of the v1 review (`VLBeauClaudeOpus`, 2026-05-06). 5 atomic commits, all CI gates green:

- ✅ `ruff check src/ tests/` — All checks passed
- ✅ `mypy --strict src/` — 23 source files, no issues
- ✅ `pytest --cov-fail-under=85` — **432 passed**, coverage **85.41%** (was 84.66%)

## Commits

| Commit | Scope | Review item |
|---|---|---|
| `9e521c7` | fix(registry): CI red gates — ruff x4, mypy x2 | **C1** |
| `bd8a03d` | test(registry): enforce MCP wrapper wiring for 6 `capability_*` tools | **M2** |
| `8f86c66` | fix(registry): `datetime.utcnow()` → `datetime.now(UTC)` (3 sites) | **C3** |
| `02aea17` | fix(registry): `capability_announce` raises `MCPValidationError` on bad payload | **M3** |
| `b083757` | fix(registry): guard `CapabilityRegistry._cache` with `threading.RLock` | **M4** |

## What changed

### C1 — CI red gates
- F401 ×3 : removed unused imports (`asyncio`, `unittest.mock.patch`, `pytest`) in registry tests.
- RUF003 : `×` → `x` in `test_query.py` comment.
- mypy `unused-ignore` : dropped stale `# type: ignore[arg-type]` in `storage.py:95`.
- mypy `type-arg` : `asyncio.Task` → `asyncio.Task[None]` in `heartbeat.py:24`.

### M2 — MCP wrapper tests (pattern v0.7.7)
Added 6 regression tests in `test_server.py` that access each `@mcp.tool()` wrapper via `_tool_manager._tools[name].fn`. They would fail if `build_server()` stopped wiring `cap_registry.announce`, `cap_query.*`, or `heartbeat.ping` — closing the same test-isolation trap that motivated the v0.7.7 hardening pass.

### C3 — `datetime.utcnow()` deprecation
3 sites migrated (`models.py`, `heartbeat.py`, `server.py`). Bonus: `AgentInfo.last_heartbeat` is now timezone-aware; the SQLite round-trip via `datetime.fromisoformat()` preserves tz correctly.

### M3 — `except Exception` → structured validation
`capability_announce` now:
1. Goes through `validate_tool_params()` (new case `capability_announce` + `_validate_capability_announce` helper) — symmetric with every other MCP tool.
2. Catches `pydantic.ValidationError` and re-raises as `MCPValidationError`, matching the v0.7.7 wrapper contract.

Test suite updated: `test_capability_announce_wrapper_rejects_bad_payload` now uses `pytest.raises`, and `test_capability_announce_wrapper_rejects_empty_payload` is added.

### M4 — Thread-safety on `_cache`
`CapabilityRegistry._cache` is now protected by a `threading.RLock` around every mutation (`announce`) and every read (`query`, `get_agent`, `get_all_agents`). The read path snapshots the dict under the lock, then does filtering outside — keeps the critical section short.

Regression test `test_concurrent_announce_and_query_no_race` spawns 2 writers + 2 readers hammering the cache for 200 ms and asserts no exception bubbles up. Reliably reproduced the `RuntimeError: dictionary changed size during iteration` before the fix; clean after.

> **Note** — this `RLock` becomes redundant once the registry is migrated to a SQLite-backed store (ADR Option B, deferred to a follow-up PR per the user's 2026-05-05 decision). Kept as a minimal-scope, merge-safe correction for v0.8.

## Explicitly out of scope

These were raised in the v1 review but deferred:

| Item | Reason |
|---|---|
| **M1** — rename `max_cost` → `max_cost_usd` / `max_tokens` | API-breaking; separate PR after product review |
| **C2 / Option B** — centralised registry via `a2a-bus.sqlite` | Deferred per user decision (2026-05-05); needs dedicated ADR, schema migration, cross-host ACL reasoning |
| Minor nits (m1–m4: orphan example, `AgentInfo.name` uniqueness, cache TTL, `payload: str` vs `AgentInfo`) | Not blocking; track separately |

## Test plan

```bash
ruff check src/ tests/          # must pass
python -m mypy --strict src/    # must pass
pytest --cov=src --cov-fail-under=85
```

Manual: run a multi-threaded smoke test against `build_server()` — no `dictionary changed size during iteration` under the same heartbeat + query mix that reproduced it locally.

---

🤖 Reviewed + fixed by VLBeauClaudeOpus (Claude Opus 4.7)
