### PR TITLE
chore: release v0.8.0 — Capability Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-06
+
+### Added
+
+- **Capability Registry** — agents advertise the skills they offer via 5 new
+  MCP tools. Bridge maintains a SQLite-backed registry (currently local per
+  bridge — centralisation tracked in a follow-up issue):
+  - `capability_announce(payload)` — register/update an agent's capabilities
+    from an `AgentInfo` JSON payload. Validated through
+    `validate_tool_params("capability_announce", …)`; raises
+    `MCPValidationError` on bad JSON or Pydantic validation failure.
+  - `capability_query(keyword, max_cost)` — filter registered agents by
+    keyword match (skill_id / description / domain) and/or USD cost ceiling.
+  - `capability_discover()` — list every capability across all registered
+    agents, with agent metadata.
+  - `capability_find_best(skill, max_cost)` — scored match against a skill
+    keyword, optional token-cost ceiling.
+  - `capability_ping(agent_id)` — heartbeat, used by `HeartbeatManager` to
+    mark agents offline after `2 × A2A_HEARTBEAT_INTERVAL` of silence.
+- **Registry data model** (`src/a2a_mcp_bridge/registry/models.py`) —
+  Pydantic `AgentInfo`, `Capability`, `CostModel` (tokens, latency, monetary
+  cost, local/api/hybrid type).
+- **Registry storage** (`src/a2a_mcp_bridge/registry/storage.py`) — SQLite
+  schema with `agents` and `capabilities` tables, full CRUD, cache warm-up
+  on startup.
+- **Heartbeat manager** (`src/a2a_mcp_bridge/registry/heartbeat.py`) —
+  async lifecycle task that sweeps stale agents; interval configurable via
+  `A2A_HEARTBEAT_INTERVAL` env var (default 30 s).
+- **Registry CLI sub-commands** — `registry discover`, `registry list-agents`,
+  `registry find-best <skill>` for ops inspection.
+- **Example client** (`examples/hermes_agent_client.py`) — minimal agent
+  announce + heartbeat loop.
+- **37 new tests** covering models, storage, manager, query, heartbeat, plus
+  6 MCP wrapper tests in `test_server.py` (pattern borrowed from v0.7.7:
+  accessed via `_tool_manager._tools[name].fn`, fail if `build_server()`
+  stops wiring a capability_* tool) and 1 concurrency regression test
+  (`test_concurrent_announce_and_query_no_race`).
+  Full suite: **432/432 passing**, coverage **85.41 %** (gate 85 %).
+
+### Changed
+
+- `capability_announce` wrapper now raises `MCPValidationError` on invalid
+  payloads (was returning `{"status": "error", "message": …}`) — aligned
+  with every other MCP tool wrapper shipped in v0.7.7.
+- `validate_tool_params()` now handles the `capability_announce` case with
+  a dedicated `_validate_capability_announce()` helper (rejects empty or
+  non-string payload before JSON parsing).
+- `AgentInfo.last_heartbeat` is now **timezone-aware** (UTC). SQLite
+  round-trip via `datetime.fromisoformat()` preserves the tzinfo.
+
+### Fixed
+
+- **Thread-safety** on `CapabilityRegistry._cache` — guarded by a
+  `threading.RLock` around every mutation (`announce`) and every read
+  (`query`, `get_agent`, `get_all_agents`). Before the lock,
+  `HeartbeatManager._cleanup_stale_agents()` mutating the cache from an
+  async background task while an MCP tool iterated `self._cache.values()`
+  could raise `RuntimeError: dictionary changed size during iteration`.
+  Regression test `test_concurrent_announce_and_query_no_race` reliably
+  reproduced the crash before the fix.
+- **Deprecated `datetime.utcnow()`** replaced with `datetime.now(UTC)` in
+  three sites (`registry/models.py`, `registry/heartbeat.py`,
+  `server.py:capability_discover`). Prevents future CI fails under
+  `-W error::DeprecationWarning` on Python 3.12+.
+- **CI red gates restored to green** — 4 ruff errors (F401 × 3 + RUF003)
+  + 2 mypy `--strict` errors (`unused-ignore` in `registry/storage.py`,
+  missing `Task[None]` in `registry/heartbeat.py`) cleaned up.
+
+### Deferred (tracked as follow-up issues)
+
+- **Rename `max_cost` → `max_cost_usd` / `max_tokens`** — the param name is
+  ambiguous (USD in `manager.query`, tokens in `query.find_best`). Not
+  fixed here because it's API-breaking; handled in a separate PR.
+- **Registry centralisation (Option B)** — fuse `{db}.registry.db` into
+  `a2a-bus.sqlite` so the 10-VPS fleet shares a single capability table.
+  Needs dedicated ADR, schema migration, cross-host ACL reasoning.
+- Minor polish: orphan `examples/hermes_agent_client.py` (README link),
+  `AgentInfo.name` uniqueness, cache TTL hardening,
+  `capability_announce(agent: AgentInfo)` vs `payload: str`.
+
 ## [0.7.7] — 2026-05-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-mcp-bridge"
-version = "0.7.7"
+version = "0.8.0"
 description = "MCP server for agent-to-agent messaging — A2A-style peer-to-peer bus exposed as MCP tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/a2a_mcp_bridge/__init__.py
+++ b/src/a2a_mcp_bridge/__init__.py
@@ -1,3 +1,3 @@
 """a2a-mcp-bridge — MCP server for agent-to-agent messaging."""
 
-__version__ = "0.7.7"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-mcp-bridge"
-version = "0.7.7"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary

Version bump **0.7.7 → 0.8.0** for the Capability Registry feature (merged as PR #50).

This is a **minor** release per SemVer — purely additive public API (5 new MCP tools + 1 changed exception shape on `capability_announce`).

## What's in this PR

- `pyproject.toml` + `src/a2a_mcp_bridge/__init__.py` + `uv.lock` → `0.8.0`
- `CHANGELOG.md` → new `[0.8.0] — 2026-05-06` section with full Added / Changed / Fixed / Deferred breakdown

## Test plan

```bash
ruff check src/ tests/          # ✓ clean
python -m mypy --strict src/    # ✓ clean
pytest --cov-fail-under=85      # ✓ 432/432, coverage 85.41%
python -c "import a2a_mcp_bridge; print(a2a_mcp_bridge.__version__)"  # ✓ 0.8.0
```

## Release highlights

### Added
- **Capability Registry** — agents advertise skills via 5 new MCP tools: `capability_announce`, `capability_query`, `capability_discover`, `capability_find_best`, `capability_ping`
- SQLite-backed storage (local per bridge — centralisation tracked as follow-up)
- Async `HeartbeatManager` with stale-agent cleanup (configurable interval)
- Registry CLI sub-commands (`registry discover`, `list-agents`, `find-best`)
- 37 + 6 + 1 new tests (432 total, up from 396)

### Fixed (v1 review follow-up)
- Thread-safety race on `CapabilityRegistry._cache` (`threading.RLock`)
- `datetime.utcnow()` deprecation (3 sites → `datetime.now(UTC)`)
- CI gates restored to green (4 ruff + 2 mypy errors)

### Changed
- `capability_announce` raises `MCPValidationError` on bad payload (was returning error dict — aligned with v0.7.7 wrapper contract)

### Deferred (follow-up issues)
- M1 — rename `max_cost` → `max_cost_usd` / `max_tokens` (API-breaking)
- C2 — Registry centralisation (Option B, fuse into `a2a-bus.sqlite`)
- 4 minor polish items (orphan example, `AgentInfo.name` uniqueness, cache TTL, `payload: str` vs `AgentInfo`)

---

🤖 Released by VLBeauClaudeOpus (Claude Opus 4.7)
