### PR TITLE
security: apply hardenings C-01, C-02, C-04 (clean rebase)

### DIFF
--- a/src/a2a_mcp_bridge/store.py
+++ b/src/a2a_mcp_bridge/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -28,6 +29,31 @@ from .signals import SignalDir
 SCHEMA_PATH: Path = Path(__file__).parent / "schema.sql"
 
 logger = logging.getLogger(__name__)
+
+# C-02 hardening: defense-in-depth whitelist for SQL identifiers passed to
+# string-formatted statements (PRAGMA table_info, ALTER TABLE). Even though
+# all callers gate on ``_KNOWN_TABLES``, we re-validate the identifier here
+# to catch any future code path that bypasses the whitelist.
+#
+# We use ``re.fullmatch`` (not ``re.match``) because Python's ``$`` anchors
+# at end-of-string OR before a trailing newline, which would let
+# ``"agents\n"`` slip through.
+_SQL_IDENTIFIER_RE = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+
+
+def _validate_sql_identifier(identifier: str, context: str = "identifier") -> None:
+    """Raise ValueError unless *identifier* is a safe SQLite identifier.
+
+    A safe identifier matches ``^[a-zA-Z_][a-zA-Z0-9_]*$`` — no quotes,
+    no spaces, no semicolons, no newlines. This is defense-in-depth
+    against SQL injection in code paths that interpolate identifiers
+    into statements.
+    """
+    if not identifier or not _SQL_IDENTIFIER_RE.fullmatch(identifier):
+        raise ValueError(
+            f"invalid {context} {identifier!r}: "
+            "must match [a-zA-Z_][a-zA-Z0-9_]*"
+        )
 
 
 class Store:
@@ -126,6 +152,11 @@ class Store:
             raise ValueError(
                 f"unknown table {table!r} — only {sorted(self._KNOWN_TABLES)} are allowed"
             )
+        # C-02: defense-in-depth — even though *table* is whitelisted above,
+        # re-validate it against the SQL-identifier regex before we
+        # interpolate it into a PRAGMA / ALTER statement.
+        _validate_sql_identifier(table, "table name")
+        _validate_sql_identifier(column, "column name")
         existing_cols = {
             row["name"]
             for row in self._conn.execute(

--- a/src/a2a_mcp_bridge/transfers.py
+++ b/src/a2a_mcp_bridge/transfers.py
@@ -73,15 +73,24 @@ def transfer_path(transfer_id: str, sha256_hex: str, filename: str) -> Path:
     return base / transfer_id / f"{sha256_hex[:16]}_{filename}"
 
 
-def is_safe_path(candidate: Path) -> bool:
+def is_safe_path(candidate: Path | str) -> bool:
     """Return True iff *candidate*'s realpath lives under the transfer dir.
 
-    Defends against path-traversal (``../../etc/passwd``) and symlink
-    escapes. Both sides of the check are resolved via :func:`os.path.realpath`.
+    Defends against:
+
+    * path-traversal (``../../etc/passwd``),
+    * symlink escapes — both sides resolved via :func:`os.path.realpath`,
+    * C-01: null bytes and ASCII control chars (< 0x20) — these can be
+      used to truncate the path inside lower layers (libc ``open``,
+      sqlite, logging) or to bypass naive substring checks.
     """
+    candidate_str = str(candidate) if isinstance(candidate, Path) else candidate
+    # C-01: reject null bytes / control chars before touching the FS.
+    if any(ord(c) < 32 for c in candidate_str):
+        return False
     base = os.path.realpath(resolve_transfer_dir())
     try:
-        real = os.path.realpath(candidate)
+        real = os.path.realpath(candidate_str)
     except OSError:
         return False
     base_sep = base if base.endswith(os.sep) else base + os.sep
@@ -204,6 +213,10 @@ def stage_file(
     sha, actual_size = _hash_and_copy(source, staging_tmp)
     final = transfer_path(tid, sha, filename)
     os.rename(staging_tmp, final)
+    # C-04: defense-in-depth — _hash_and_copy already opens with 0o600,
+    # but re-assert it after the rename in case the source file had
+    # broader permissions on a filesystem that doesn't honour O_EXCL mode.
+    os.chmod(final, 0o600)
 
     # Write meta.json atomically
     manifest = {
@@ -223,6 +236,8 @@ def stage_file(
     meta_tmp = meta_dir / "meta.json.tmp"
     meta_tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True))
     os.rename(meta_tmp, meta_dir / "meta.json")
+    # C-04: harden manifest permissions (write_text honours umask, often 0o644).
+    os.chmod(meta_dir / "meta.json", 0o600)
 
     return TransferRecord(
         transfer_id=tid,

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,174 @@
+"""Regression tests for security hardenings C-01, C-02, C-04.
+
+Each test name explicitly references its hardening ID so a future grep
+for ``C-01`` / ``C-02`` / ``C-04`` lands on its guard. Do not delete
+these without updating ``security_audit.md``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from a2a_mcp_bridge.store import Store, _validate_sql_identifier
+from a2a_mcp_bridge.transfers import is_safe_path, stage_file
+
+# ---------------------------------------------------------------------------
+# C-01 — null bytes & control chars rejected by is_safe_path
+# ---------------------------------------------------------------------------
+
+
+class TestC01PathValidation:
+    """C-01: is_safe_path() rejects null bytes and ASCII control chars.
+
+    Null bytes can truncate paths inside libc/sqlite/logging layers and
+    bypass naive substring filters. Control chars (< 0x20) can break log
+    parsers and terminal output. Both are rejected before any FS syscall.
+    """
+
+    def test_rejects_null_byte(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        assert is_safe_path(f"{tmp_path}/foo\x00bar") is False
+
+    def test_rejects_newline(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        assert is_safe_path(f"{tmp_path}/foo\nbar") is False
+
+    def test_rejects_carriage_return(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        assert is_safe_path(f"{tmp_path}/foo\rbar") is False
+
+    def test_rejects_tab(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        # Tab is 0x09 — below 0x20, so rejected.
+        assert is_safe_path(f"{tmp_path}/foo\tbar") is False
+
+    def test_rejects_low_ascii_byte(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        # Bell char (0x07) — should be rejected.
+        assert is_safe_path(f"{tmp_path}/foo\x07bar") is False
+
+    def test_accepts_normal_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sanity check: ordinary paths still work."""
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        assert is_safe_path(tmp_path / "abc" / "file.md") is True
+
+    def test_accepts_unicode_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sanity check: non-ASCII >= 0x20 must NOT be rejected."""
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        assert is_safe_path(tmp_path / "café" / "résumé.md") is True
+
+
+# ---------------------------------------------------------------------------
+# C-02 — SQL identifier whitelist (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+class TestC02SqlIdentifierValidation:
+    """C-02: _validate_sql_identifier() enforces ``[a-zA-Z_][a-zA-Z0-9_]*``.
+
+    Even though ``Store.ensure_column`` gates on ``_KNOWN_TABLES``, we
+    re-validate the identifier through the regex before string-formatting
+    it into a PRAGMA / ALTER statement. This catches future code paths
+    that bypass the whitelist or are introduced by a regression.
+    """
+
+    @pytest.mark.parametrize(
+        "good",
+        ["agents", "messages", "_internal", "table1", "Foo_Bar_42", "_"],
+    )
+    def test_accepts_valid_identifier(self, good: str) -> None:
+        # Should not raise.
+        _validate_sql_identifier(good)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",                          # empty
+            "1agents",                   # starts with digit
+            "agents; DROP TABLE x",      # SQL injection
+            "agents--",                  # SQL comment
+            "agents'",                   # quote
+            'agents"',                   # double quote
+            "agents OR 1=1",             # space + SQL
+            "agents.column",             # dot
+            "agents`",                   # backtick
+            "agents\x00",                # null byte
+            "agents\n",                  # newline
+            "agents/*evil*/",            # block comment
+            "agents-bad",                # hyphen
+        ],
+    )
+    def test_rejects_invalid_identifier(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_sql_identifier(bad)
+
+    def test_ensure_column_helper_exists(self, store: Store) -> None:
+        """Smoke test: the validate_sql_identifier helper is wired in.
+
+        We don't reach the regex through ``_add_column_if_missing`` because
+        the ``_KNOWN_TABLES`` whitelist intercepts bad table names first —
+        which is exactly the layered defense we want. This test just
+        confirms the helper is importable and callable from the same module.
+        """
+        from a2a_mcp_bridge.store import _validate_sql_identifier as v
+
+        v("agents")  # sanity
+        with pytest.raises(ValueError):
+            v("agents; DROP")
+
+
+# ---------------------------------------------------------------------------
+# C-04 — staged file & manifest hardened to 0o600
+# ---------------------------------------------------------------------------
+
+
+class TestC04FilePermissions:
+    """C-04: stage_file() writes both payload and manifest with mode 0o600.
+
+    Default umask on shared hosts can leave files world-readable. Forcing
+    0o600 ensures only the staging user can read transferred payloads
+    (which may contain secrets, screenshots, etc.).
+    """
+
+    def test_staged_payload_is_0o600(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        src = tmp_path / "source.md"
+        src.write_text("secret\n")
+
+        rec = stage_file(src, sender_id="alice", recipient_id="bob", filename="source.md")
+
+        mode = os.stat(rec.locator_path).st_mode & 0o777
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_manifest_is_0o600(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        src = tmp_path / "source.md"
+        src.write_text("secret\n")
+
+        rec = stage_file(src, sender_id="alice", recipient_id="bob", filename="source.md")
+
+        manifest_path = tmp_path / rec.transfer_id / "meta.json"
+        assert manifest_path.is_file()
+        mode = os.stat(manifest_path).st_mode & 0o777
+        assert mode == 0o600, f"expected 0o600 on manifest, got {oct(mode)}"
+
+    def test_perms_resist_loose_umask(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even with a lax umask (0o000 → world-writable default), final files are 0o600."""
+        monkeypatch.setenv("A2A_TRANSFER_DIR", str(tmp_path))
+        src = tmp_path / "source.md"
+        src.write_text("secret\n")
+
+        old_umask = os.umask(0o000)
+        try:
+            rec = stage_file(src, sender_id="alice", recipient_id="bob", filename="source.md")
+        finally:
+            os.umask(old_umask)
+
+        payload_mode = os.stat(rec.locator_path).st_mode & 0o777
+        manifest_mode = os.stat(tmp_path / rec.transfer_id / "meta.json").st_mode & 0o777
+        assert payload_mode == 0o600, f"payload {oct(payload_mode)}"
+        assert manifest_mode == 0o600, f"manifest {oct(manifest_mode)}"


### PR DESCRIPTION
## Summary

Apply 3 security hardenings from `security_audit.md` (C-01, C-02, C-04) on top of `main` — **replaces** `fix/store-bugs` which had problems (see below).

## Changes

### C-01 — `transfers.py::is_safe_path()` rejects null bytes & control chars

`is_safe_path()` now rejects any path containing bytes `< 0x20`. Null bytes can truncate paths inside libc/sqlite/logging layers and bypass naive substring filters. Newlines/control chars can break log parsers and terminal output. All rejected before any FS syscall.

### C-02 — `store.py::_validate_sql_identifier()` SQL identifier whitelist

New private helper validating identifiers against `^[a-zA-Z_][a-zA-Z0-9_]*$` before they hit `PRAGMA table_info` or `ALTER TABLE`. `_add_column_if_missing()` calls it for both `table` and `column` arguments. Defense-in-depth — `_KNOWN_TABLES` whitelist already gates the public path, but this catches future code paths that might bypass the whitelist.

Uses `re.fullmatch` (not `re.match`) because Python's `$` anchor matches before a trailing newline, which would let `"agents\n"` slip through.

### C-04 — explicit `os.chmod(0o600)` on staged file & manifest

`stage_file()` now `os.chmod(final, 0o600)` after the rename (defense-in-depth — `_hash_and_copy` already opens with `O_EXCL+0o600`, but `os.rename` semantics + cross-FS edge cases warrant re-asserting). The `meta.json` manifest is also chmod'd to `0o600` after `write_text()` since `write_text` honours the user's umask, which is often `0o644`.

## Tests

30 new tests in `tests/test_security_hardening.py`, organised by hardening ID for grep-ability:

- **C-01**: 7 tests — null byte, newline, CR, tab, low-ASCII, normal path, unicode path.
- **C-02**: parametrised over 6 valid + 13 malicious identifiers (SQL injection, comments, quotes, null bytes, dots, hyphens) + smoke test.
- **C-04**: payload mode, manifest mode, resilience under loose umask `0o000`.

## CI

- `ruff check src/ tests/` ✅
- `mypy src/` ✅
- `pytest --cov-fail-under=85` ✅ — **481 tests passing, coverage 85.67%** (was 451 / 85.51%).

## Why this replaces `fix/store-bugs`

I reviewed `fix/store-bugs` (commit `8d20751`) and found 4 blockers:

1. **Duplicated already-merged PR #57.** Branch contained `af069eb` "fix(store): correct 3 bugs — race condition, missing timeout, erroneous COMMIT before raise" — same 3 fixes as PR #57 already merged on `main`. Branch was started before #57 merged and never rebased. Merging would create a guaranteed conflict.
2. **CI ruff broken — 18 errors.** Trailing whitespace in docstrings, `SIM108`, 9 unused imports, 2 unused locals, `I001` import order. Pipeline `ruff check src/ tests/` would have failed.
3. **Indentation bug in `store.py:327-331`.** The `INSERT INTO ...` SQL string and `execute()` arguments were indented 8 cols inside a `try:` block expecting 12. Python doesn't crash (the args are wrapped in `(...)`), but it's wrong and would conflict at rebase with the cleaner version already on `main`.
4. **Zero new tests for the 3 hardenings.** Commit message claimed "451 tests passing" but no test asserted the new behaviour — for security fixes that's rédhibitoire.

This branch is rebased clean on top of `main`, ruff/mypy/pytest green, and ships explicit regression tests for each hardening.

## Closes

- Supersedes `fix/store-bugs` (can be deleted after merge).
- Refs: `security_audit.md` C-01, C-02, C-04.
