### PR TITLE
fix: document AgentRecord.online default breaking change

### DIFF
--- a/src/a2a_mcp_bridge/models.py
+++ b/src/a2a_mcp_bridge/models.py
@@ -76,13 +76,23 @@ class Message(BaseModel):
 
 
 class AgentRecord(BaseModel):
-    """Registry entry for an agent profile."""
+    """Registry entry for an agent profile.
+
+    .. note:: ``online`` defaults to ``False`` (v0.10.2+). Previously the field
+        was required — callers that omitted ``online`` would get a
+        ``ValidationError``. The default was introduced because liveness is
+        always decided at the server layer (see ``Store.list_agents`` and
+        ``HttpBusStore``), so requiring the caller to pass ``online=False``
+        was redundant. This is a **breaking change** for code that relied on
+        the field being mandatory to catch construction errors, but no such
+        code path existed in the bridge itself.
+    """
     model_config = ConfigDict(frozen=True)
 
     agent_id: str
     first_seen_at: datetime
     last_seen_at: datetime
-    online: bool = False
+    online: bool = False  # Default since v0.10.2 — liveness is server-layer concern
     metadata: dict[str, Any] | None = Field(default=None)  # Strict type
 
     @field_validator("agent_id")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,6 +66,22 @@ class TestAgentRecord:
         assert rec.online is True
         assert rec.metadata == {"capabilities": ["chat"]}
 
+    def test_online_defaults_to_false(self):
+        """v0.10.2 breaking change: online is now optional with default False.
+
+        Previously, omitting ``online`` would raise ValidationError. Now it
+        silently defaults to False — liveness is always decided at the server
+        layer, not at construction time.
+        """
+        now = datetime.now(UTC)
+        rec = AgentRecord(
+            agent_id="a",
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+        assert rec.online is False
+        assert rec.metadata is None
+
 
 class TestSendResult:
     def test_valid(self):


### PR DESCRIPTION
## Context

Opus review flagged that `online: bool = False` in `AgentRecord` (added in v0.10.2 / PR #65) is a **silent breaking change**: previously the field was required — omitting it would raise `ValidationError`. Now it silently defaults to `False`.

## Impact analysis

Both internal call sites already pass `online=False` explicitly:
- `Store.list_agents` → `online=False, # liveness is decided at the server layer`
- `HttpBusStore` → `online=data.get("online", False)`

No code path in the bridge was relying on the field being mandatory. The default is semantically correct (liveness is always server-side).

## Fix

- **Docstring note** on `AgentRecord` documenting the v0.10.2 breaking change and rationale
- **Inline comment** on `online: bool = False`
- **Test** `test_online_defaults_to_false` — captures the new behaviour explicitly